### PR TITLE
Feat/docker compose

### DIFF
--- a/.github/workflows/published_release.yml
+++ b/.github/workflows/published_release.yml
@@ -1,0 +1,29 @@
+name: New release published
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+
+      - name: Update version in files
+        run: |
+          sed -i -E "s|ghcr.io/seaweedbraincy/jellyfin-newsletter:v[0-9]+\.[0-9]+\.[0-9]+|ghcr.io/seaweedbraincy/jellyfin-newsletter:${{ github.event.release.tag_name }}|g" README.md
+          sed -i -E "s|ghcr.io/seaweedbraincy/jellyfin-newsletter:v[0-9]+\.[0-9]+\.[0-9]+|ghcr.io/seaweedbraincy/jellyfin-newsletter:${{ github.event.release.tag_name }}|g" docker-compose.yml
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          
+          git add README.md docker-compose.yml
+          git commit -m "chore: bump image version to ${{ github.event.release.tag_name }}"
+          git push

--- a/.github/workflows/security_test.yml
+++ b/.github/workflows/security_test.yml
@@ -24,4 +24,4 @@ jobs:
       run: python3 -m pip install semgrep
     
     - name: Run semgrep
-      run:  semgrep scan --error 
+      run:  semgrep scan --error  --exclude-rule dockerfile.security.missing-user.missing-user 

--- a/.github/workflows/security_test.yml
+++ b/.github/workflows/security_test.yml
@@ -24,4 +24,4 @@ jobs:
       run: python3 -m pip install semgrep
     
     - name: Run semgrep
-      run:  semgrep scan --error  --exclude-rule dockerfile.security.missing-user.missing-user 
+      run:  semgrep scan --error  --exclude-rule dockerfile.security.missing-user.missing-user --exclude-rule  dockerfile.security.missing-user-entrypoint.missing-user-entrypoint

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ config/config.yml
 template/new_media_notification_preview.html
 
 
+# Used for development purposes, contains local settings and other files that should not be committed
+dev/
+
 
 
 # Byte-compiled / optimized / DLL files

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ COPY requirements.txt /app
 COPY main.py /app
 COPY template /app/template
 COPY assets /app/assets
-
+COPY entrypoint.sh /app/entrypoint.sh
+COPY config/config-example.yml /app/default/config-example.yml
 WORKDIR /app
 
 RUN apt update 
@@ -31,5 +32,4 @@ RUN apt remove -y python3-dev build-essential libssl-dev libffi-dev python3-setu
 RUN apt autoremove -y
 
 
-USER 1001:1001
-CMD ["python", "main.py"]
+CMD ["entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN apt remove -y python3-dev build-essential libssl-dev libffi-dev python3-setu
 RUN apt autoremove -y
 
 
-CMD ["/app/entrypoint.sh"]
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ COPY template /app/template
 COPY assets /app/assets
 COPY entrypoint.sh /app/entrypoint.sh
 COPY config/config-example.yml /app/default/config-example.yml
+
+
 WORKDIR /app
+
+RUN chmod +x /app/entrypoint.sh
 
 RUN apt update 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN chmod +x /app/entrypoint.sh
 
 RUN apt update 
 
-RUN apt install -y --no-install-recommends locales python3-pip python3-dev build-essential libssl-dev libffi-dev python3-setuptools gcc
+RUN apt install -y --no-install-recommends locales python3-pip python3-dev build-essential libssl-dev libffi-dev python3-setuptools gcc gosu
 
 RUN echo "fr_FR.UTF-8 UTF-8" >> /etc/locale.gen && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -36,4 +36,4 @@ RUN apt remove -y python3-dev build-essential libssl-dev libffi-dev python3-setu
 RUN apt autoremove -y
 
 
-CMD ["entrypoint.sh"]
+CMD ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ docker run --rm \
 # Unix :
 crontab -e
 # Add the following line to run the script every 1st of the month at 8am
-0 8 1 * * root docker run --rm -v $(pwd)/config.yml:/app/config/config.yml -e USER_UID=1001 -e USER_GID=1001  ghcr.io/seaweedbraincy/jellyfin-newsletter:v0.6.0
+0 8 1 * * root docker run --rm -v PATH_TO_CONFIG_FOLDER/config:/app/config/ ghcr.io/seaweedbraincy/jellyfin-newsletter:v0.6.0
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ recipients:
 ```bash
 docker run --rm \
     -v ./config.yml:/app/config/config.yml \
+    -e USER_UID='1001' \
+    -e USER_GID='1001' \
     ghcr.io/seaweedbraincy/jellyfin-newsletter:latest
 ```
 *Note: It is recommended to use a static version instead of  `latest`, and manually upgrade. [Last version](https://github.com/SeaweedbrainCY/jellyfin-newsletter/pkgs/container/jellyfin-newsletter)*
@@ -135,7 +137,7 @@ docker run --rm \
 # Unix :
 crontab -e
 # Add the following line to run the script every 1st of the month at 8am
-0 8 1 * * root docker run --rm -v $(pwd)/config.yml:/app/config/config.yml ghcr.io/seaweedbraincy/jellyfin-newsletter:latest
+0 8 1 * * root docker run --rm -v $(pwd)/config.yml:/app/config/config.yml -e USER_UID=1001 -e USER_GID=1001  ghcr.io/seaweedbraincy/jellyfin-newsletter:latest
 ```
 *Note: It is recommended to use a static version instead of `latest`, and manually upgrade. [Last version](https://github.com/SeaweedbrainCY/jellyfin-newsletter/pkgs/container/jellyfin-newsletter)*
 

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -22,8 +22,8 @@ jellyfin:
         - ""
         # example for /tv folder add "tv"
   
-  # Number of days to look back for new items
-  observed_period_days: 30
+    # Number of days to look back for new items
+    observed_period_days: 30
 
 tmdb:
     # TMDB API key, see requirements for more info

--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -1,6 +1,13 @@
 ### Example configuration file.
 ## All values are mandatory, except for the ones that are commented out.
 
+scheduler:
+    # Crontab expression to send the newsletter. 
+    # Comment the scheduler section to disable the automatic sending of the newsletter. WARNING: IF COMMENTED, THE NEWSLETTER WILL BE RAN ONCE AT THE START OF THE CONTAINER.
+    # Test your crontab expression here: https://crontab.guru/
+    # This example will send the newsletter on the first day of every month at 8:00 AM
+    cron: "0 8 1 * *"
+    
 
 jellyfin:
     # URL of your jellyfin server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 services:
   jellyfin-newsletter:
     container_name: jellyfin-newsletter
-    image: 'ghcr.io/seaweedbraincy/jellyfin-newsletter:latest'
+    image: 'ghcr.io/seaweedbraincy/jellyfin-newsletter:dev'
     environment:
       USER_UID: 1000
       USER_GID: 1000
       TZ: 'America/Toronto'
+      CRON : 0 8 1 * *  # Run the newsletter on the first day of each month at 8:00 AM
       
-
+    restart: unless-stopped
     volumes:
       - './config:/app/config'
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       
 
     volumes:
-      - './config.yml:/app/config/config.yml'
+      - './config:/app/config'
     
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       USER_UID: 1000
       USER_GID: 1000
       TZ: 'America/Toronto'
-      CRON : 0 8 1 * *  # Run the newsletter on the first day of each month at 8:00 AM
-      
     restart: unless-stopped
     volumes:
       - './config:/app/config'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  jellyfin-newsletter:
+    container_name: jellyfin-newsletter
+    image: 'ghcr.io/seaweedbraincy/jellyfin-newsletter:latest'
+    environment:
+      USER_UID: 1000
+      USER_GID: 1000
+      TZ: 'America/Toronto'
+      
+
+    volumes:
+      - './config.yml:/app/config/config.yml'
+    
+
+
+
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,11 @@
 services:
   jellyfin-newsletter:
     container_name: jellyfin-newsletter
-    image: 'ghcr.io/seaweedbraincy/jellyfin-newsletter:dev'
+    image: 'ghcr.io/seaweedbraincy/jellyfin-newsletter:v0.6.0'
     environment:
       USER_UID: 1000
       USER_GID: 1000
       TZ: 'America/Toronto'
-    restart: unless-stopped
     volumes:
       - './config:/app/config'
     

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,35 @@
+#! /bin/bash 
+
+
+####
+# Pre-execution set up 
+# User: root
+####
+
+set -e 
+
+
+if [ "$USER_UID" = "" ]; then
+    echo "USER_UID environment variable is not set. Defaulting to 1001"
+    USER_UID="1001"
+fi
+
+if [ "$USER_GID" = "" ]; then
+    echo "USER_GID environment variable is not set. Defaulting to 1001"
+    USER_GID="1001"
+fi
+
+# Check if config file exists
+if [ ! -f /app/config/config.yml && ! -f /app/config/config.yaml  ]; then
+    echo "Config file not found. Generating default config."
+    cp /app/default/config-example.yml /app/config/config.yml 
+    cp /app/default/config-example.yml /app/config/config-example.yaml
+fi
+
+chown -R $USER_UID:$USER_GID /app/config/
+
+###
+# Switch to user 1001 and execute the main script
+###
+
+exec gosu $USER_UID:$USER_GID python main.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,7 +20,7 @@ if [ "$USER_GID" = "" ]; then
 fi
 
 # Check if config file exists
-if [ ! -f /app/config/config.yml && ! -f /app/config/config.yaml  ]; then
+if  [ ! -f /app/config/config.yml ] && [ ! -f /app/config/config.yaml ]; then
     echo "Config file not found. Generating default config."
     cp /app/default/config-example.yml /app/config/config.yml 
     cp /app/default/config-example.yml /app/config/config-example.yaml

--- a/main.py
+++ b/main.py
@@ -141,7 +141,7 @@ def send_newsletter():
 
     email_controller.send_email(template)
 
-    logging.info("""All done here. Exiting.
+    logging.info("""All emails sent.
     
     
 ##############################################
@@ -170,6 +170,8 @@ if __name__ == "__main__":
 Jellyfin Newsletter is starting ....
 ##############################################
 
+WARNING : This version includes breaking changes. 
+Make sure to review breaking changes in https://github.com/SeaweedbrainCY/jellyfin-newsletter/releases before running the newsletter.
 
 """)
     logging.info("Checking configuration ...")

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import sys
 from source import configuration, JellyfinAPI, TmdbAPI, email_template, email_controller
 import datetime as dt
 from source.configuration import logging
+from source.configuration_checker import check_configuration
 
 
 
@@ -66,6 +67,13 @@ Jellyfin Newsletter is starting ....
 
 
 """)
+    logging.info("Checking configuration ...")
+    try:
+        check_configuration()
+    except Exception as e:
+        logging.error(f"[FATAL] Configuration check failed: {e}")
+        sys.exit(1)
+    logging.info("Configuration check passed.")
 
     folders = JellyfinAPI.get_root_items()
     watched_film_folders_id = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
+APScheduler==3.11.0
 certifi==2025.1.31
 charset-normalizer==3.4.1
 idna==3.10
 PyYAML==6.0.2
 requests==2.32.4
+tzlocal==5.3.1
 urllib3==2.5.0

--- a/source/configuration.py
+++ b/source/configuration.py
@@ -7,6 +7,16 @@ logging.basicConfig(
 )
 
 
+class Scheduler:
+    def __init__(self, data):
+        if "cron" not in data:
+            logging.info("No cron expression given. The newsletter will run once at startup and then stop.")
+            self.enabled = False
+        else:
+            self.enabled = True
+            self.cron = data["cron"]
+            
+
 class Jellyfin:
     required_keys = ["url", "api_token",  "watched_film_folders", "watched_tv_folders", "observed_period_days"]
     def __init__(self, data):
@@ -71,6 +81,7 @@ class Config:
         self.email_template = EmailTemplate(data["email_template"])
         self.email = Email(data["email"])
         self.recipients = data["recipients"]
+        self.scheduler = Scheduler(data["scheduler"]) if "scheduler" in data else Scheduler([])
     
     
 

--- a/source/configuration_checker.py
+++ b/source/configuration_checker.py
@@ -78,6 +78,11 @@ def check_recipients_configuration():
     assert isinstance(conf.recipients, list), "[FATAL] Invalid recipients configuration. The recipients must be a list. Please check the configuration."
     
 
+def check_scheduler_configuration():
+    if conf.scheduler.enabled:
+        assert isinstance(conf.scheduler.cron, str), "[FATAL] Invalid scheduler cron expression. The cron expression must be a string. Please check the configuration."
+
+
 def check_configuration():
     """
     Check if the configuration is valid.

--- a/source/configuration_checker.py
+++ b/source/configuration_checker.py
@@ -1,0 +1,92 @@
+from source.configuration import conf
+from source.configuration import logging
+import re
+from urllib.parse import urlparse
+
+def check_jellyfin_configuration():
+    
+    # Jellyfin URL
+    parsed_url = urlparse(conf.jellyfin.url)
+    assert parsed_url.scheme != '', "[FATAL] Invalid Jellyfin URL. The URL must contain the scheme (e.g. http:// or https://). Please check the configuration."
+    assert parsed_url.netloc != '', "[FATAL] Invalid Jellyfin URL. The URL must contain a valid host (e.g. example.com or 127.0.0.1:80). Please check the configuration."
+
+    # Jellyfin API token
+    assert isinstance(conf.jellyfin.api_token, str), "[FATAL] Invalid Jellyfin API token. The API token must be a string. Please check the configuration."
+    assert conf.jellyfin.api_token != '', "[FATAL] Invalid Jellyfin API token. The API token cannot be empty. Please check the configuration."
+
+    # watched_film_folders 
+    assert isinstance(conf.jellyfin.watched_film_folders, list), "[FATAL] Invalid watched film folders. The watched film folders must be a list. Please check the configuration."
+    
+    # watched_tv_folders
+    assert isinstance(conf.jellyfin.watched_tv_folders, list), "[FATAL] Invalid watched TV folders. The watched TV folders must be a list. Please check the configuration."
+
+    # observed_period_days
+    assert isinstance(conf.jellyfin.observed_period_days, int), "[FATAL] Invalid observed period days. The observed period days must be an integer. Please check the configuration."
+
+
+
+def check_tmdb_configuration():
+    # TMDB API key
+    assert isinstance(conf.tmdb.api_key, str), "[FATAL] Invalid TMDB API key. The API key must be a string. Please check the configuration."
+    assert conf.tmdb.api_key != '', "[FATAL] Invalid TMDB API key. The API key cannot be empty. Please check the configuration."
+
+
+def email_template_configuration():
+    # Language
+    assert isinstance(conf.email_template.language, str), "[FATAL] Invalid email template language. The language must be a string. Please check the configuration."
+    assert conf.email_template.language in ['en', 'fr'], "[FATAL] Invalid email template language. The language must be either 'en' or 'fr'. Please check the configuration."
+
+    # Subject
+    assert isinstance(conf.email_template.subject, str), "[FATAL] Invalid email template subject. The subject must be a string. Please check the configuration."
+
+    # Title
+    assert isinstance(conf.email_template.title, str), "[FATAL] Invalid email template title. The title must be a string. Please check the configuration."
+
+    # Subtitle
+    assert isinstance(conf.email_template.subtitle, str), "[FATAL] Invalid email template subtitle. The subtitle must be a string. Please check the configuration."
+
+    # Jellyfin URL
+    assert isinstance(conf.email_template.jellyfin_url, str), "[FATAL] Invalid email template Jellyfin URL. The Jellyfin URL must be a string. Please check the configuration."
+
+    # Unsubscribe email
+    assert isinstance(conf.email_template.unsubscribe_email, str), "[FATAL] Invalid email template unsubscribe email. The unsubscribe email must be a string. Please check the configuration."
+
+    # Jellyfin owner name
+    assert isinstance(conf.email_template.jellyfin_owner_name, str), "[FATAL] Invalid email template Jellyfin owner name. The Jellyfin owner name must be a string. Please check the configuration."
+
+
+def check_email_configuration():
+    # SMTP server
+    assert isinstance(conf.email.smtp_server, str), "[FATAL] Invalid email SMTP server. The SMTP server must be a string. Please check the configuration."
+    assert conf.email.smtp_server != '', "[FATAL] Invalid email SMTP server. The SMTP server cannot be empty. Please check the configuration."
+
+    # SMTP port
+    assert isinstance(conf.email.smtp_port, int), "[FATAL] Invalid email SMTP port. The SMTP port must be an integer. Please check the configuration."
+    assert conf.email.smtp_port > 0, "[FATAL] Invalid email SMTP port. The SMTP port must be greater than 0. Please check the configuration."
+
+    # SMTP username
+    assert isinstance(conf.email.smtp_user, str), "[FATAL] Invalid email SMTP username. The SMTP username must be a string. Please check the configuration."
+    assert conf.email.smtp_user != '', "[FATAL] Invalid email SMTP username. The SMTP username cannot be empty. Please check the configuration."
+
+    # SMTP password
+    assert isinstance(conf.email.smtp_password, str), "[FATAL] Invalid email SMTP password. The SMTP password must be a string. Please check the configuration."
+    assert conf.email.smtp_password != '', "[FATAL] Invalid email SMTP password. The SMTP password cannot be empty. Please check the configuration."
+
+
+def check_recipients_configuration():
+    # Recipients
+    assert isinstance(conf.recipients, list), "[FATAL] Invalid recipients configuration. The recipients must be a list. Please check the configuration."
+    
+
+def check_configuration():
+    """
+    Check if the configuration is valid.
+    The goal is to ensure all values fetched from the configuration file are valid.
+    """
+    check_jellyfin_configuration()
+    check_tmdb_configuration()
+    email_template_configuration()
+    check_email_configuration()
+    check_recipients_configuration()
+    
+    


### PR DESCRIPTION
**This pull request introduces breaking changes**
- Fix #10 
    * Introduce a new scheduler option in config file, to define as a contab the schedule of each run 
    * If not defined, the script will continue to run only once, at startup
- Fix #16 
    * The entrypoint is now verifying that necessary files exists and if not, create them. 
    * The entrypoint now oversee that the python script will run as non-root, instead of defining it in the dockerfile 
- Add support of docker compose
- Add a configuration checker to ensure config values are correct, expected and consistent
- Improve documentation to reflect changes