### PR TITLE
Feat/adapt media display based on count

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,7 +23,7 @@ fi
 if  [ ! -f /app/config/config.yml ] && [ ! -f /app/config/config.yaml ]; then
     echo "Config file not found. Generating default config."
     cp /app/default/config-example.yml /app/config/config.yml 
-    cp /app/default/config-example.yml /app/config/config-example.yaml
+    cp /app/default/config-example.yml /app/config/config-example.yml
 fi
 
 chown -R $USER_UID:$USER_GID /app/config/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,5 @@
 #! /bin/bash 
 
-
 ####
 # Pre-execution set up 
 # User: root
@@ -20,10 +19,21 @@ if [ "$USER_GID" = "" ]; then
 fi
 
 # Check if config file exists
-if  [ ! -f /app/config/config.yml ] && [ ! -f /app/config/config.yaml ]; then
-    echo "Config file not found. Generating default config."
+
+if [ -f /app/config/config.yaml ] && [ ! -f /app/config/config.yml ]; then
+    echo "config.yaml found, renaming to config.yml"
+    mv /app/config/config.yaml /app/config/config.yml
+fi
+
+
+if  [ ! -f /app/config/config.yml ]; then
+    echo "WARNING. Config file not found. Generating default config."
     cp /app/default/config-example.yml /app/config/config.yml 
     cp /app/default/config-example.yml /app/config/config-example.yml
+    echo "Config file generated at /app/config/config.yml"
+    echo "Please edit the config file before running the application."
+    echo "Refer to the documentation for more information."
+    exit 1
 fi
 
 chown -R $USER_UID:$USER_GID /app/config/

--- a/main.py
+++ b/main.py
@@ -188,8 +188,7 @@ if __name__ == "__main__":
 Jellyfin Newsletter is starting ....
 ##############################################
 
-WARNING : This version includes breaking changes. 
-Make sure to review breaking changes in https://github.com/SeaweedbrainCY/jellyfin-newsletter/releases before running the newsletter.
+
 
 """)
     logging.info("Checking configuration ...")

--- a/source/JellyfinAPI.py
+++ b/source/JellyfinAPI.py
@@ -1,13 +1,13 @@
-from source import configuration
+from source.configuration import conf, logging
 import requests
 import datetime as dt
 
 def get_root_items():
     headers = {
-        "Authorization": f'MediaBrowser Token="{configuration.conf.jellyfin.api_token}"'
+        "Authorization": f'MediaBrowser Token="{conf.jellyfin.api_token}"'
     }
 
-    response = requests.get(f'{configuration.conf.jellyfin.url}/Items', headers=headers)
+    response = requests.get(f'{conf.jellyfin.url}/Items', headers=headers)
     if response.status_code != 200:
         logging.error(f"Error while getting the root items, status code: {response.status_code}.")
         raise Exception(f"Error while getting the root items, status code: {response.status_code}. Answer: {response.text}.")
@@ -18,12 +18,12 @@ def get_item_from_parent(parent_id, type, minimum_creation_date=None):
     if type not in ["movie", "tv"]:
         raise Exception(f"Error while retrieving a media from Jellyfin. Type must be 'movie' or 'tv'. Got {type}")
     headers = {
-        "Authorization": f'MediaBrowser Token="{configuration.conf.jellyfin.api_token}"'
+        "Authorization": f'MediaBrowser Token="{conf.jellyfin.api_token}"'
     }
 
 
 
-    response = requests.get(f'{configuration.conf.jellyfin.url}/Items?ParentId={parent_id}&fields=DateCreated,ProviderIds&Recursive=true', headers=headers)
+    response = requests.get(f'{conf.jellyfin.url}/Items?ParentId={parent_id}&fields=DateCreated,ProviderIds&Recursive=true', headers=headers)
     if response.status_code != 200:
         logging.error(f"Error while getting the items from parent, status code: {response.status_code}.")
         raise Exception(f"Error while getting the items from parent, status code: {response.status_code}. Answer: {response.text}.")
@@ -34,15 +34,17 @@ def get_item_from_parent(parent_id, type, minimum_creation_date=None):
         for item in response.json()["Items"]:
             creation_date = dt.datetime.strptime(item["DateCreated"].split("T")[0], "%Y-%m-%d")
             if creation_date > minimum_creation_date:
+                logging.debug(f"Item {item['Name']} is more recent than {minimum_creation_date} (added on {creation_date}). Adding it to the list.")
+                logging.debug("Item details: " + str(item))
                 recent_items.append(item)
         return recent_items, response.json()["TotalRecordCount"]
 
 
 def get_item_from_parent_by_name(parent_id, name):
     headers = {
-        "Authorization": f'MediaBrowser Token="{configuration.conf.jellyfin.api_token}"'
+        "Authorization": f'MediaBrowser Token="{conf.jellyfin.api_token}"'
     }
-    response = requests.get(f'{configuration.conf.jellyfin.url}/Items?ParentId={parent_id}&fields=DateCreated,ProviderIds&Recursive=true', headers=headers)
+    response = requests.get(f'{conf.jellyfin.url}/Items?ParentId={parent_id}&fields=DateCreated,ProviderIds&Recursive=true', headers=headers)
     if response.status_code != 200:
         logging.error(f"Error while getting the items from parent, status code: {response.status_code}.")
         raise Exception(f"Error while getting the items from parent, status code: {response.status_code}. Answer: {response.text}.")

--- a/source/configuration.py
+++ b/source/configuration.py
@@ -1,10 +1,7 @@
 import yaml
 import logging
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s'
-)
+
 
 
 class Scheduler:
@@ -87,11 +84,19 @@ class Config:
             if key not in data:
                 logging.error(f"[FATAL] Load config fail. Was expecting the key {key}")
                 exit(1)
+
+        if "debug" in data: 
+            if data["debug"]:
+                logging.basicConfig(level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+            else:
+                logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+        else: 
+            logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     
         self.jellyfin = Jellyfin(data["jellyfin"])
         self.tmdb = Tmdb(data["tmdb"])
         self.email_template = EmailTemplate(data["email_template"])
-        self.email = Email(data["email"])
+        self.email = Email(data["email"]) 
         self.recipients = data["recipients"]
         self.scheduler = Scheduler(data["scheduler"]) if "scheduler" in data else Scheduler([])
     

--- a/source/configuration_checker.py
+++ b/source/configuration_checker.py
@@ -7,8 +7,8 @@ def check_jellyfin_configuration():
     
     # Jellyfin URL
     parsed_url = urlparse(conf.jellyfin.url)
-    assert parsed_url.scheme != '', "[FATAL] Invalid Jellyfin URL. The URL must contain the scheme (e.g. http:// or https://). Please check the configuration."
-    assert parsed_url.netloc != '', "[FATAL] Invalid Jellyfin URL. The URL must contain a valid host (e.g. example.com or 127.0.0.1:80). Please check the configuration."
+    assert parsed_url.scheme != '', f"[FATAL] Invalid Jellyfin URL. The URL must contain the scheme (e.g. http:// or https://). Please check the configuration. Got {conf.jellyfin.url}. Parsed : {parsed_url}"
+    assert parsed_url.netloc != '', f"[FATAL] Invalid Jellyfin URL. The URL must contain a valid host (e.g. example.com or 127.0.0.1:80). Please check the configuration. Got {conf.jellyfin.url}. Parsed : {parsed_url}"
 
     # Jellyfin API token
     assert isinstance(conf.jellyfin.api_token, str), "[FATAL] Invalid Jellyfin API token. The API token must be a string. Please check the configuration."


### PR DESCRIPTION
- Population is now based on Episodes only and the overall Series information are populated after.
- This allow to display the newly added episodes. Fix #8.
- This add more control over what has been added.
- The creation date is no longer based on the series and/or season but on the last episode added. This should help to fix issue 28. At least this will help to avoid confusion linked to the added date displayed which was not linked to the elements recently added
- Fix #24
. When possible, display episodes instead of seasons number