### PR TITLE
implement implicit TLS support

### DIFF
--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -59,7 +59,7 @@ email_template:
 email:
     # Example: GMail: smtp.gmail.com
     smtp_server: ""
-    # Usually 587
+    # Usually 587 (STARTTLS) or 465 (implicit TLS)
     smtp_port: 
     # The username of your SMTP account
     smtp_username: ""
@@ -67,6 +67,8 @@ email:
     smtp_password: ""
     # Example: "jellyfin@example.com" or to set display username "Jellyfin <jellyfin@example.com>"
     smtp_sender_email: ""
+    # TLS Type for the SMTP connection
+    smtp_tls_type: "STARTTLS" # "STARTTLS" or "TLS" (implicit TLS)
 
 
 # List of users to send the newsletter to

--- a/source/configuration.py
+++ b/source/configuration.py
@@ -74,6 +74,7 @@ class Email:
         self.smtp_user = data["smtp_username"]
         self.smtp_password = data["smtp_password"]
         self.smtp_sender_email = data["smtp_sender_email"]
+        self.smtp_tls_type = data.get("smtp_tls_type") or "STARTTLS" # Fallback to STARTTLS if not specified
 
         
 

--- a/source/email_controller.py
+++ b/source/email_controller.py
@@ -9,13 +9,18 @@ from time import sleep
 
 
 def send_email(html_content):
-    try:
-        smtp_server = smtplib.SMTP(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
-        smtp_server.connect(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
-        smtp_server.starttls()
+    try:      
+        tls_type = configuration.conf.email.smtp_tls_type.upper()
+        if tls_type == "TLS":
+            smtp_server = smtplib.SMTP_SSL(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
+        else:
+            if tls_type != "STARTTLS":
+                logging.warning(f"No or unknown TLS type specified ('{tls_type}'), falling back to STARTTLS.")
+            smtp_server = smtplib.SMTP(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
+            smtp_server.starttls()
         smtp_server.login(configuration.conf.email.smtp_user, configuration.conf.email.smtp_password)
     except Exception as e:
-        raise Exception(f"Error while connecting to the SMTP server. Got error : {e}")
+        raise Exception(f"Error while connecting to the SMTP server. Got error: {e}")
     
     for recipient in configuration.conf.recipients:
         msg = MIMEMultipart('alternative')


### PR DESCRIPTION
This pull request introduces support for specifying the TLS type for SMTP connections in the email configuration. 
`STARTTLS` is used as default value to avoid a breaking change, but implicit TLS [is recommended](https://www.rfc-editor.org/rfc/rfc8314) nowadays.