### PR TITLE
optimize Dockerfile for layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,8 @@
 FROM python:3.12-slim
 
-RUN mkdir -p /app/config
-
-COPY source /app/source
-COPY requirements.txt /app
-COPY main.py /app
-COPY template /app/template
-COPY assets /app/assets
-COPY entrypoint.sh /app/entrypoint.sh
-COPY config/config-example.yml /app/default/config-example.yml
-
-
 WORKDIR /app
 
-RUN chmod +x /app/entrypoint.sh
-
-RUN apt update 
-
-RUN apt install -y --no-install-recommends locales python3-pip python3-dev build-essential libssl-dev libffi-dev python3-setuptools gcc gosu
+RUN apt update && apt install -y --no-install-recommends locales python3-pip python3-dev build-essential libssl-dev libffi-dev python3-setuptools gcc gosu
 
 RUN echo "fr_FR.UTF-8 UTF-8" >> /etc/locale.gen && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
@@ -27,6 +12,8 @@ ENV LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
     LC_ALL=en_US.UTF-8
 
+COPY requirements.txt /app
+
 RUN pip install --no-cache --upgrade pip setuptools
 
 RUN pip install --upgrade pip
@@ -35,5 +22,15 @@ RUN apt remove -y python3-dev build-essential libssl-dev libffi-dev python3-setu
 
 RUN apt autoremove -y
 
+RUN mkdir -p /app/config
+
+COPY source /app/source
+COPY main.py /app
+COPY template /app/template
+COPY assets /app/assets
+COPY entrypoint.sh /app/entrypoint.sh
+COPY config/config-example.yml /app/default/config-example.yml
+
+RUN chmod +x /app/entrypoint.sh
 
 ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
 - consolidated `apt update` and `apt install` commands into a single command to follow dockerfile best practices and avoid problems due to layer caching
- moved copy of application source files after apt install to speed up container rebuild for local debugging by utilizing docker layer caching