### PR TITLE
ci: fix docker images for forked repositories

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -45,7 +45,7 @@ jobs:
           uses: docker/login-action@v3
           with:
             registry: ghcr.io
-            username: ${{ secrets.USERNAME }}
+            username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Build and push Docker images
@@ -54,9 +54,9 @@ jobs:
             context: .
             push: true
             tags: |
-              ghcr.io/${{ secrets.USERNAME }}/jellyfin-newsletter:latest
-              ghcr.io/${{ secrets.USERNAME }}/jellyfin-newsletter:${{ env.CURRENT_VERSION }}
-              ghcr.io/${{ secrets.USERNAME }}/jellyfin-newsletter:${{ env.CURRENT_SHORT_VERSION }}
+              ghcr.io/${{ github.repository }}/jellyfin-newsletter:latest
+              ghcr.io/${{ github.repository }}/jellyfin-newsletter:${{ env.CURRENT_VERSION }}
+              ghcr.io/${{ github.repository }}/jellyfin-newsletter:${{ env.CURRENT_SHORT_VERSION }}
             labels: |
               org.opencontainers.image.revision=${{ env.GIT_COMMIT }}
               org.opencontainers.image.created=${{ steps.meta.outputs.created }}

--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -54,9 +54,9 @@ jobs:
             context: .
             push: true
             tags: |
-              ghcr.io/${{ github.repository }}/jellyfin-newsletter:latest
-              ghcr.io/${{ github.repository }}/jellyfin-newsletter:${{ env.CURRENT_VERSION }}
-              ghcr.io/${{ github.repository }}/jellyfin-newsletter:${{ env.CURRENT_SHORT_VERSION }}
+              ghcr.io/${{ github.repository }}:latest
+              ghcr.io/${{ github.repository }}:${{ env.CURRENT_VERSION }}
+              ghcr.io/${{ github.repository }}:${{ env.CURRENT_SHORT_VERSION }}
             labels: |
               org.opencontainers.image.revision=${{ env.GIT_COMMIT }}
               org.opencontainers.image.created=${{ steps.meta.outputs.created }}

--- a/.github/workflows/build_and_deploy_dev.yml
+++ b/.github/workflows/build_and_deploy_dev.yml
@@ -41,7 +41,7 @@ jobs:
           uses: docker/login-action@v3
           with:
             registry: ghcr.io
-            username: ${{ secrets.USERNAME }}
+            username: ${{ github.actor }}
             password: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Build and push Docker images
@@ -50,8 +50,8 @@ jobs:
             context: .
             push: true
             tags: |
-              ghcr.io/${{ secrets.USERNAME }}/jellyfin-newsletter:dev
-              ghcr.io/${{ secrets.USERNAME }}/jellyfin-newsletter:${{ github.ref_name }}
+              ghcr.io/${{ github.repository }}:dev
+              ghcr.io/${{ github.repository }}:${{ github.ref_name }}
             labels: |
               org.opencontainers.image.revision=${{ env.GIT_COMMIT }}
               org.opencontainers.image.created=${{ env.DATE }}


### PR DESCRIPTION
This pull request updates the Docker build and deployment workflows to use GitHub repository and actor information for image tagging and authentication instead of relying on custom secrets. This change allows the workflows to run in forked repositories without additional configuration and makes it easy to build dev images for testing new implementations.

References:
- https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context
- https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages