### PR TITLE
fix: handle tmdb API not found error gracefully

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,11 +78,19 @@ def populate_series_item_with_series_related_information(series_items, watched_t
                         tmdb_id = item["ProviderIds"]["Tmdb"]
     
                 if tmdb_id is not None: # id provided by Jellyfin
-                    tmdb_info = TmdbAPI.get_media_detail_from_id(id=tmdb_id, type="tv")
-                else:
-                    logging.info(f"Item {item} has no TMDB id, searching by title.")
-                    tmdb_info = TmdbAPI.get_media_detail_from_title(title=item["Name"], type="tv", year=item["ProductionYear"])
-                
+                    try:
+                        tmdb_info = TmdbAPI.get_media_detail_from_id(id=tmdb_id, type="tv")
+                    except Exception as e:
+                        logging.error(f"Item {item['Name']} could not be retrieved from TMDB by id due to an API error: {e}")     
+                        logging.info(f"Retrying search for item {item} by title.")
+
+                if tmdb_id is None or tmdb_info is None:
+                    logging.info(f"Item {item} has no TMDB id or search by id failed. Searching by title.")
+                    try:
+                        tmdb_info = TmdbAPI.get_media_detail_from_title(title=item["Name"], type="tv", year=item["ProductionYear"])
+                    except Exception as e:
+                        logging.error(f"Item {item['Name']} could not be retrieved from TMDB by title due to an API error: {e}")   
+                                       
                 if tmdb_info is None:
                     logging.warning(f"Item {item['Name']} has not been found on TMDB. Skipping.")
                 else:

--- a/source/TmdbAPI.py
+++ b/source/TmdbAPI.py
@@ -61,5 +61,7 @@ def get_media_detail_from_id(id, type):
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         logging.error(f"Error while getting media detail from id, status code: {response.status_code}.")
+        if response.status_code == 404:
+            return None
         raise Exception(f"Error while getting media detail from id, status code: {response.status_code}. Answer: {response.text}.")
     return response.json()

--- a/source/TmdbAPI.py
+++ b/source/TmdbAPI.py
@@ -61,7 +61,5 @@ def get_media_detail_from_id(id, type):
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         logging.error(f"Error while getting media detail from id, status code: {response.status_code}.")
-        if response.status_code == 404:
-            return None
         raise Exception(f"Error while getting media detail from id, status code: {response.status_code}. Answer: {response.text}.")
     return response.json()


### PR DESCRIPTION
This pull request makes a targeted improvement to error handling in the `get_media_detail_from_id` function.  
The function now returns `None` if the response status code is 404, instead of raising an exception. This prevents crashing the whole newsletter application when a requested media item is not available in TMDB anymore. An error that the details could not be retrieved is then logged directly in `main.py`.