### PR TITLE
fix: ensure default value for display_overview_max_items is set correctly

### DIFF
--- a/source/configuration.py
+++ b/source/configuration.py
@@ -62,7 +62,7 @@ class EmailTemplate:
         self.jellyfin_url = data["jellyfin_url"]
         self.unsubscribe_email = data["unsubscribe_email"]
         self.jellyfin_owner_name = data["jellyfin_owner_name"]
-        self.display_overview_max_items = data.get("display_overview_max_items") or 10
+        self.display_overview_max_items = data.get("display_overview_max_items", 10)
 
 
 class Email:


### PR DESCRIPTION
This pull request makes a minor improvement to how the default value for `display_overview_max_items` is set in the configuration initialization. The change ensures that "0" will display the overview regardless of the item count, instead of beeing  treated as False and replaced by 10

* Updated the assignment of `display_overview_max_items` in the `__init__` method of `source/configuration.py` to use the default parameter in `dict.get()`, ensuring not falling back to 10 when "display_overview_max_items" is set to "0".