### PR TITLE
feat: Add preview and dry-run functionality

### DIFF
--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -82,6 +82,29 @@ email:
     smtp_tls_type: "STARTTLS" # "STARTTLS" or "TLS" (implicit TLS)
 
 
+# Preview and testing configuration
+preview:
+    # Enable preview mode instead of sending emails
+    enabled: false
+    
+    # Test SMTP connection during preview (dry-run mode)
+    # true = dry-run: test SMTP connection but don't send
+    # false = preview-only: skip SMTP entirely
+    test_smtp_connection: false
+    
+    # Directory to save preview files
+    output_directory: "/app/config/previews/"
+    
+    # Preview filename pattern (supports {date}, {timestamp} placeholders)
+    output_filename: "newsletter_{date}.html"
+    
+    # Include generation metadata in HTML comments
+    include_metadata: true
+    
+    # Save email data as JSON file alongside HTML
+    save_email_data: true
+
+
 # List of users to send the newsletter to
 recipients:
   - ""

--- a/main.py
+++ b/main.py
@@ -198,10 +198,25 @@ def send_newsletter():
     if len(movie_items) + len(series_items) > 0:
         template = email_template.populate_email_template(movies=movie_items, series=series_items, total_tv=total_tv, total_movie=total_movie)
 
+        # Use the new send_newsletter function with preview/dry-run support
+        result = email_controller.send_newsletter(
+            html_content=template,
+            movies=movie_items,
+            series=series_items,
+            total_tv=total_tv,
+            total_movie=total_movie
+        )
 
-        email_controller.send_email(template)
-
-        logging.info("All emails sent.")
+        # Log results based on mode
+        if result["mode"] == "normal":
+            logging.info(f"All emails sent successfully to {result['sent_count']} recipients.")
+        elif result["mode"] == "preview":
+            logging.info(f"Preview generated successfully (preview-only mode).")
+        elif result["mode"] == "dry-run":
+            smtp_status = "PASSED" if result["smtp_tested"] else "FAILED"
+            logging.info(f"Dry-run completed. SMTP test: {smtp_status}")
+        
+        logging.info("Newsletter processing completed.")
     else:
         logging.warning("No new items found in watched folders. No email sent.")
     

--- a/source/configuration.py
+++ b/source/configuration.py
@@ -78,6 +78,16 @@ class Email:
         self.smtp_sender_email = data["smtp_sender_email"]
         self.smtp_tls_type = data.get("smtp_tls_type") or "STARTTLS" # Fallback to STARTTLS if not specified
 
+
+class PreviewConfig:
+    def __init__(self, data):
+        self.enabled = data.get("enabled", False)
+        self.test_smtp_connection = data.get("test_smtp_connection", False)
+        self.output_directory = data.get("output_directory", "./previews/")
+        self.output_filename = data.get("output_filename", "newsletter_{date}_{time}.html")
+        self.include_metadata = data.get("include_metadata", True)
+        self.save_email_data = data.get("save_email_data", True)
+
         
 
 class Config:
@@ -102,13 +112,14 @@ class Config:
         self.email = Email(data["email"]) 
         self.recipients = data["recipients"]
         self.scheduler = Scheduler(data["scheduler"]) if "scheduler" in data else Scheduler([])
+        self.preview = PreviewConfig(data.get("preview", {}))
     
     
 
 
 
 try:
-    with open("./config/config.yml") as config_yml:
+    with open("./config/config.yml", encoding='utf-8') as config_yml:
         try:
             raw_conf = yaml.safe_load(config_yml)
             conf = Config(raw_conf)

--- a/source/configuration_checker.py
+++ b/source/configuration_checker.py
@@ -89,6 +89,37 @@ def check_scheduler_configuration():
         assert isinstance(conf.scheduler.cron, str), "[FATAL] Invalid scheduler cron expression. The cron expression must be a string. Please check the configuration."
 
 
+def check_preview_configuration():
+    # enabled
+    assert isinstance(conf.preview.enabled, bool), "[FATAL] Invalid preview.enabled. The enabled flag must be a boolean. Please check the configuration."
+    
+    # test_smtp_connection  
+    assert isinstance(conf.preview.test_smtp_connection, bool), "[FATAL] Invalid preview.test_smtp_connection. The test_smtp_connection flag must be a boolean. Please check the configuration."
+    
+    # output_directory
+    assert isinstance(conf.preview.output_directory, str), "[FATAL] Invalid preview.output_directory. The output_directory must be a string. Please check the configuration."
+    assert conf.preview.output_directory != '', "[FATAL] Invalid preview.output_directory. The output_directory cannot be empty. Please check the configuration."
+    
+    # output_filename
+    assert isinstance(conf.preview.output_filename, str), "[FATAL] Invalid preview.output_filename. The output_filename must be a string. Please check the configuration."
+    assert conf.preview.output_filename != '', "[FATAL] Invalid preview.output_filename. The output_filename cannot be empty. Please check the configuration."
+    
+    # include_metadata
+    assert isinstance(conf.preview.include_metadata, bool), "[FATAL] Invalid preview.include_metadata. The include_metadata flag must be a boolean. Please check the configuration."
+    
+    # save_email_data
+    assert isinstance(conf.preview.save_email_data, bool), "[FATAL] Invalid preview.save_email_data. The save_email_data flag must be a boolean. Please check the configuration."
+    
+    # If preview enabled, validate directory exists or can be created
+    if conf.preview.enabled:
+        import os
+        try:
+            os.makedirs(conf.preview.output_directory, exist_ok=True)
+        except Exception as e:
+            logging.error(f"[FATAL] Cannot create preview output directory '{conf.preview.output_directory}': {e}")
+            exit(1)
+
+
 def check_configuration():
     """
     Check if the configuration is valid.
@@ -99,5 +130,6 @@ def check_configuration():
     email_template_configuration()
     check_email_configuration()
     check_recipients_configuration()
+    check_preview_configuration()
     
     

--- a/source/email_controller.py
+++ b/source/email_controller.py
@@ -1,5 +1,6 @@
 from source import configuration
 from source import context
+from source.preview_handler import PreviewHandler
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
@@ -9,8 +10,126 @@ from source.utils import save_last_newsletter_date
 import datetime as dt
 
 
+def send_newsletter(html_content, movies=None, series=None, total_tv=0, total_movie=0):
+    """
+    Send newsletter or generate preview based on configuration
+    
+    Args:
+        html_content (str): Generated HTML email content
+        movies (dict): Movies data for metadata
+        series (dict): Series data for metadata  
+        total_tv (int): Total TV episodes count
+        total_movie (int): Total movie count
+    
+    Returns:
+        dict: Result information
+    """
+    # Check if preview mode is enabled
+    if configuration.conf.preview.enabled:
+        return _handle_preview_mode(html_content, movies or {}, series or {}, total_tv, total_movie)
+    else:
+        return _send_normal_email(html_content)
 
-def send_email(html_content):
+
+def _handle_preview_mode(html_content, movies, series, total_tv, total_movie):
+    """Handle preview or dry-run mode"""
+    preview_handler = PreviewHandler()
+    
+    if configuration.conf.preview.test_smtp_connection:
+        # Dry-run mode: test SMTP + save preview
+        mode = "dry-run"
+        smtp_tested = False
+        
+        try:
+            _test_smtp_connection()
+            smtp_tested = True
+            logging.info("SMTP connection test: SUCCESS")
+        except Exception as e:
+            logging.error(f"SMTP connection test: FAILED - {e}")
+            
+        # Generate metadata with SMTP test result
+        metadata = preview_handler.get_metadata(movies, series, total_tv, total_movie, mode, smtp_tested)
+        
+        # Calculate email size
+        metadata['stats']['total_email_size_kb'] = round(len(html_content.encode('utf-8')) / 1024, 1)
+        
+        # Save preview files
+        html_file, json_file = preview_handler.save_preview(html_content, metadata, mode)
+        
+        # Log dry-run results
+        logging.info("DRY-RUN MODE RESULTS:")
+        logging.info(f"Would send to: {', '.join(configuration.conf.recipients)}")
+        logging.info(f"Email size: {metadata['stats']['total_email_size_kb']}KB")
+        logging.info(f"Preview saved: {html_file}")
+        if json_file:
+            logging.info(f"Metadata saved: {json_file}")
+        
+        return {
+            "mode": "dry-run",
+            "smtp_tested": smtp_tested,
+            "html_file": html_file,
+            "json_file": json_file,
+            "recipients": configuration.conf.recipients,
+            "email_size_kb": metadata['stats']['total_email_size_kb']
+        }
+        
+    else:
+        # Preview-only mode: skip SMTP entirely
+        mode = "preview"
+        
+        # Generate metadata
+        metadata = preview_handler.get_metadata(movies, series, total_tv, total_movie, mode, False)
+        
+        # Calculate email size
+        metadata['stats']['total_email_size_kb'] = round(len(html_content.encode('utf-8')) / 1024, 1)
+        
+        # Save preview files
+        html_file, json_file = preview_handler.save_preview(html_content, metadata, mode)
+        
+        # Log preview results
+        logging.info("PREVIEW MODE RESULTS:")
+        logging.info(f"Email size: {metadata['stats']['total_email_size_kb']}KB")
+        logging.info(f"Preview saved: {html_file}")
+        if json_file:
+            logging.info(f"Metadata saved: {json_file}")
+        logging.info("SMTP testing skipped (preview-only mode)")
+        
+        return {
+            "mode": "preview",
+            "smtp_tested": False,
+            "html_file": html_file,
+            "json_file": json_file,
+            "email_size_kb": metadata['stats']['total_email_size_kb']
+        }
+
+
+def _test_smtp_connection():
+    """Test SMTP connection without sending email"""
+    tls_type = configuration.conf.email.smtp_tls_type.upper()
+    
+    if tls_type == "TLS":
+        smtp_server = smtplib.SMTP_SSL(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
+    elif tls_type == "STARTTLS":
+        smtp_server = smtplib.SMTP(configuration.conf.email.smtp_server, configuration.conf.email.smtp_port)
+        smtp_server.starttls()
+    else:
+        raise Exception(f"Invalid SMTP TLS type: {tls_type}")
+    
+    # Test login
+    smtp_server.login(configuration.conf.email.smtp_user, configuration.conf.email.smtp_password)
+    
+    # Test recipient validation (basic check)
+    for recipient in configuration.conf.recipients:
+        if '@' not in recipient:
+            raise Exception(f"Invalid recipient email: {recipient}")
+    
+    smtp_server.quit()
+    logging.info(f"SMTP server: {configuration.conf.email.smtp_server}:{configuration.conf.email.smtp_port}")
+    logging.info(f"Recipients validated: {len(configuration.conf.recipients)} addresses")
+
+
+def _send_normal_email(html_content):
+    """Send email normally (original functionality)"""
     try:      
         tls_type = configuration.conf.email.smtp_tls_type.upper()
         if tls_type == "TLS":
@@ -24,6 +143,7 @@ def send_email(html_content):
     except Exception as e:
         raise Exception(f"Error while connecting to the SMTP server. Got error: {e}")
     
+    sent_count = 0
     for recipient in configuration.conf.recipients:
         msg = MIMEMultipart('alternative')
         msg['Subject'] = configuration.conf.email_template.subject.format_map(context.placeholders)
@@ -34,8 +154,20 @@ def send_email(html_content):
         msg['To'] = recipient
         smtp_server.sendmail(configuration.conf.email.smtp_sender_email, recipient, msg.as_string())
         logging.info(f"Email sent to {recipient}")
+        sent_count += 1
         sleep(2)
     smtp_server.quit()
     save_last_newsletter_date(dt.datetime.now())
-
     
+    return {
+        "mode": "normal",
+        "sent_count": sent_count,
+        "recipients": configuration.conf.recipients
+    }
+
+
+# Legacy function for backwards compatibility
+def send_email(html_content):
+    """Legacy function - use send_newsletter instead"""
+    result = _send_normal_email(html_content)
+    return result

--- a/source/email_template.py
+++ b/source/email_template.py
@@ -41,7 +41,7 @@ def populate_email_template(movies, series, total_tv, total_movie) -> str:
     elif len(movies) + len(series) > configuration.conf.email_template.display_overview_max_items :
         include_overview = False
         configuration.logging.info(f"There are more than {configuration.conf.email_template.display_overview_max_items} new items, overview will not be included in the email template to avoid too much content.")
-    with open("./template/new_media_notification.html") as template_file:
+    with open("./template/new_media_notification.html", encoding='utf-8') as template_file:
         template = template_file.read()
         
         if configuration.conf.email_template.language in ["fr", "en"]:

--- a/source/preview_handler.py
+++ b/source/preview_handler.py
@@ -1,0 +1,148 @@
+import os
+import json
+import datetime
+from source import configuration
+
+
+class PreviewHandler:
+    """
+    Handles preview and dry-run functionality for the newsletter
+    """
+    
+    def __init__(self):
+        self.config = configuration.conf.preview
+        self._ensure_output_directory()
+    
+    def _ensure_output_directory(self):
+        """Create output directory if it doesn't exist"""
+        if self.config.enabled:
+            os.makedirs(self.config.output_directory, exist_ok=True)
+    
+    def _generate_filename(self, suffix=""):
+        """Generate filename with date/timestamp placeholders"""
+        filename = self.config.output_filename
+        now = datetime.datetime.now()
+        
+        # Replace placeholders
+        filename = filename.replace("{date}", now.strftime("%Y-%m-%d"))
+        filename = filename.replace("{time}", now.strftime("%H%M%S"))
+        filename = filename.replace("{timestamp}", now.strftime("%Y%m%d_%H%M%S"))
+        
+        if suffix:
+            name, ext = os.path.splitext(filename)
+            filename = f"{name}_{suffix}{ext}"
+            
+        return os.path.join(self.config.output_directory, filename)
+    
+    def _add_metadata_to_html(self, html_content, metadata):
+        """Add metadata to HTML as comments"""
+        if not self.config.include_metadata:
+            return html_content
+            
+        metadata_comment = f"""<!--
+=== JELLYFIN NEWSLETTER METADATA ===
+Generated: {metadata['generation_timestamp']}
+Mode: {metadata['mode']}
+Movies Found: {metadata['stats']['movies_count']}
+TV Episodes Found: {metadata['stats']['tv_episodes_count']}
+Template Language: {metadata['template_language']}
+SMTP Tested: {metadata.get('smtp_tested', 'N/A')}
+=== END METADATA ===
+-->
+"""
+        
+        # Insert after DOCTYPE or at the beginning
+        if '<!DOCTYPE' in html_content:
+            parts = html_content.split('>', 1)
+            if len(parts) == 2:
+                return parts[0] + '>\n' + metadata_comment + '\n' + parts[1]
+        
+        return metadata_comment + '\n' + html_content
+    
+    def save_preview(self, html_content, metadata, mode="preview"):
+        """
+        Save HTML preview and optional JSON metadata
+        
+        Args:
+            html_content (str): The generated HTML email content
+            metadata (dict): Email generation metadata
+            mode (str): "preview" or "dry-run"
+            
+        Returns:
+            tuple: (html_file_path, json_file_path or None)
+        """
+        if not self.config.enabled:
+            return None, None
+            
+        # Generate filenames
+        html_file = self._generate_filename()
+        
+        # Add metadata to HTML
+        if self.config.include_metadata:
+            html_content = self._add_metadata_to_html(html_content, metadata)
+        
+        # Save HTML file
+        with open(html_file, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+        
+        # Save JSON metadata if enabled
+        json_file = None
+        if self.config.save_email_data:
+            json_file = self._generate_filename("data").replace('.html', '.json')
+            with open(json_file, 'w', encoding='utf-8') as f:
+                json.dump(metadata, f, indent=2, ensure_ascii=False, default=str)
+        
+        return html_file, json_file
+    
+    def get_metadata(self, movies, series, total_tv, total_movie, mode="preview", smtp_tested=False):
+        """
+        Generate metadata for the email
+        
+        Args:
+            movies (dict): Movies data
+            series (dict): Series data
+            total_tv (int): Total TV episodes count
+            total_movie (int): Total movie count
+            mode (str): "preview" or "dry-run"
+            smtp_tested (bool): Whether SMTP connection was tested
+            
+        Returns:
+            dict: Email metadata
+        """
+        now = datetime.datetime.now()
+        
+        # Prepare movies data for JSON
+        movies_list = []
+        for movie_id, movie_data in movies.items():
+            movies_list.append({
+                "name": movie_data.get('name', 'Unknown'),
+                "added_date": movie_data.get('created_on', '').split('T')[0],
+                "tmdb_id": movie_data.get('tmdb_id', '')
+            })
+        
+        # Prepare series data for JSON
+        series_list = []
+        for serie_id, serie_data in series.items():
+            series_list.append({
+                "series_name": serie_data.get('series_name', 'Unknown'),
+                "seasons": serie_data.get('seasons', []),
+                "episodes": serie_data.get('episodes', []),
+                "added_date": serie_data.get('created_on', '').split('T')[0]
+            })
+        
+        return {
+            "generation_timestamp": now.isoformat(),
+            "mode": mode,
+            "smtp_tested": smtp_tested,
+            "jellyfin_server": configuration.conf.email_template.jellyfin_url,
+            "stats": {
+                "movies_count": total_movie,
+                "tv_episodes_count": total_tv,
+                "total_email_size_kb": 0  # Will be calculated after HTML generation
+            },
+            "movies": movies_list,
+            "tv_shows": series_list,
+            "recipients": configuration.conf.recipients if mode == "dry-run" else ["preview-mode"],
+            "template_language": configuration.conf.email_template.language,
+            "configuration_hash": str(hash(str(configuration.conf.__dict__)))
+        }


### PR DESCRIPTION
## Why
This feature addresses the need to test newsletter generation and email configuration without sending emails to actual recipients. It's particularly valuable for debugging template changes, testing SMTP connections, and reviewing newsletter content before distribution.

## New Features
**Preview Mode**: Generate HTML newsletter files locally without sending emails
**Dry-Run Mode**: Test SMTP connection and generate preview files without sending (same as Preview mode, but with SMTP test).
**Cross-Platform Path Handling**: Works seamlessly on Windows, Linux, and macOS (I had issue with file path when running straight from Python, so it's a bit more robust there)
**Timestamp Placeholders for Preview files**: Support for `{date}`, `{time}`, and `{timestamp}` in filenames

## Configuration
```yaml
preview:
  enabled: true                              # Enable preview/dry-run mode
  test_smtp_connection: false               # true = dry-run, false = preview only
  output_directory: "/app/config/previews/" # Output directory for preview files
  output_filename: "newsletter_{date}_{time}.html" # Filename template with placeholders
  include_metadata: true                    # Save metadata JSON file
  save_email_data: true                     # Include email data in metadata