### PR TITLE
Fix/scheduled next run logging

### DIFF
--- a/engine-go/internal/cron/scheduler.go
+++ b/engine-go/internal/cron/scheduler.go
@@ -13,7 +13,7 @@ func CreateNewsletterScheduler(
 ) (gocron.Scheduler, gocron.Job, error) {
 	scheduler, err := gocron.NewScheduler()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	job, err := scheduler.NewJob(

--- a/engine-go/internal/cron/scheduler.go
+++ b/engine-go/internal/cron/scheduler.go
@@ -10,7 +10,7 @@ import (
 func CreateNewsletterScheduler(
 	newsletterWorkflow newsletter.Workflow,
 	app *app.ApplicationContext,
-) (gocron.Scheduler, error) {
+) (gocron.Scheduler, gocron.Job, error) {
 	scheduler, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
@@ -21,14 +21,19 @@ func CreateNewsletterScheduler(
 		gocron.NewTask(newsletterWorkflow.Run, app),
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	jobNextRunStr := "Unknown"
-	nextRunDatetime, nextRunErr := job.NextRun()
-	if nextRunErr == nil {
-		jobNextRunStr = nextRunDatetime.Format("2006-01-02T15:04:05Z07:00")
+	return scheduler, job, nil
+}
+
+func LogNextRun(job gocron.Job, app *app.ApplicationContext) {
+	nextRunDatetime, err := job.NextRun()
+	if err != nil {
+		app.Logger.Debug("Error while computing next run.", zap.Error(err))
+		return
 	}
+	jobNextRunStr := nextRunDatetime.Format("2006-01-02T15:04:05Z07:00")
 
 	app.Logger.Info(
 		"Scheduler created.",
@@ -36,6 +41,4 @@ func CreateNewsletterScheduler(
 		zap.String("Cron expression", app.Config.Scheduler.CronExpr),
 		zap.String("Next run", jobNextRunStr),
 	)
-
-	return scheduler, nil
 }

--- a/engine-go/internal/newsletter/newsletter.go
+++ b/engine-go/internal/newsletter/newsletter.go
@@ -18,7 +18,7 @@ type Workflow struct {
 
 // Run connects to Jellyfin to retrieve the latest items and send the newsletter to the configured recipients.
 // cronjob is optional and should be nil if the workflow is not called by a scheduled job. It is mainly used for logging purposes
-func (workflow Workflow) Run(app *app.ApplicationContext, cronjob *gocron.Job) {
+func (workflow Workflow) Run(app *app.ApplicationContext) {
 	app.Logger.Info("Gathering new items and sending the newsletter ...")
 	err := workflow.JellyfinClient.TestConnection(app)
 	if err != nil {

--- a/engine-go/internal/newsletter/newsletter.go
+++ b/engine-go/internal/newsletter/newsletter.go
@@ -17,7 +17,7 @@ type Workflow struct {
 }
 
 // Run connects to Jellyfin to retrieve the latest items and send the newsletter to the configured recipients.
-// cronjob is optional and should be nil if the workflow is not called by a scheduled job. It is mainly used for logging purposes
+// cronjob is optional and should be nil if the workflow is not called by a scheduled job. It is mainly used for logging purposes.
 func (workflow Workflow) Run(app *app.ApplicationContext) {
 	app.Logger.Info("Gathering new items and sending the newsletter ...")
 	err := workflow.JellyfinClient.TestConnection(app)

--- a/engine-go/internal/newsletter/newsletter.go
+++ b/engine-go/internal/newsletter/newsletter.go
@@ -17,7 +17,8 @@ type Workflow struct {
 }
 
 // Run connects to Jellyfin to retrieve the latest items and send the newsletter to the configured recipients.
-func (workflow Workflow) Run(app *app.ApplicationContext) {
+// cronjob is optional and should be nil if the workflow is not called by a scheduled job. It is mainly used for logging purposes
+func (workflow Workflow) Run(app *app.ApplicationContext, cronjob *gocron.Job) {
 	app.Logger.Info("Gathering new items and sending the newsletter ...")
 	err := workflow.JellyfinClient.TestConnection(app)
 	if err != nil {

--- a/engine-go/internal/newsletter/newsletter_integration_test.go
+++ b/engine-go/internal/newsletter/newsletter_integration_test.go
@@ -140,7 +140,7 @@ func TestJellyfinNewsletter(t *testing.T) {
 	app.Config.SMTP.Host = mailpitCT.Host
 	app.Config.SMTP.Port = mailpitCT.SMTPPort
 
-	newsletterWorkflow.Run(app)
+	newsletterWorkflow.Run(app, nil)
 
 	messages, err := mailpitCT.GetMessages()
 	require.NoError(t, err)

--- a/engine-go/internal/newsletter/newsletter_integration_test.go
+++ b/engine-go/internal/newsletter/newsletter_integration_test.go
@@ -140,7 +140,7 @@ func TestJellyfinNewsletter(t *testing.T) {
 	app.Config.SMTP.Host = mailpitCT.Host
 	app.Config.SMTP.Port = mailpitCT.SMTPPort
 
-	newsletterWorkflow.Run(app, nil)
+	newsletterWorkflow.Run(app)
 
 	messages, err := mailpitCT.GetMessages()
 	require.NoError(t, err)

--- a/engine-go/main.go
+++ b/engine-go/main.go
@@ -62,17 +62,19 @@ func main() {
 
 	if app.Config.Scheduler.Enabled {
 		var scheduler gocron.Scheduler
-		scheduler, err = cron.CreateNewsletterScheduler(newsletterWorkflow, app)
+		var job gocron.Job
+		scheduler, job, err = cron.CreateNewsletterScheduler(newsletterWorkflow, app)
 		if err != nil {
 			app.Logger.Fatal("Error while creating the scheduler. Exiting now.", zap.Error(err))
 		}
 		scheduler.Start()
+		cron.LogNextRun(job, app)
 		// Block forever (or until signal)
 		select {}
 	}
 
 	// One time trigger
-	newsletterWorkflow.Run(app, nil)
+	newsletterWorkflow.Run(app)
 
 	app.Logger.Info("Jellyfin-Newsletter exiting gracefully.")
 }

--- a/engine-go/main.go
+++ b/engine-go/main.go
@@ -72,7 +72,7 @@ func main() {
 	}
 
 	// One time trigger
-	newsletterWorkflow.Run(app)
+	newsletterWorkflow.Run(app, nil)
 
 	app.Logger.Info("Jellyfin-Newsletter exiting gracefully.")
 }


### PR DESCRIPTION
Fix #120. 

Next run datetime is only available when the scheduler is started. This PR fixes the logging behavior to ensure it appears after firing the scheduler.