### PR TITLE
Feat/create dropping root rights entrypoint

### DIFF
--- a/engine-go/.golangci.yml
+++ b/engine-go/.golangci.yml
@@ -464,6 +464,6 @@ linters:
           - gosec
           - noctx
           - wrapcheck
-      - path: "engine-go/entrypoint/main.go"
+      - path: "entrypoint/main.go"
         linters:
           - forbidigo

--- a/engine-go/.golangci.yml
+++ b/engine-go/.golangci.yml
@@ -366,7 +366,7 @@ linters:
     nolintlint:
       # Exclude following linters from requiring an explanation.
       # Default: []
-      allow-no-explanation: [ funlen, gocognit, golines ]
+      allow-no-explanation: [funlen, gocognit, golines]
       # Enable to require an explanation of nonzero length after each nolint directive.
       # Default: false
       require-explanation: true
@@ -442,18 +442,18 @@ linters:
       - common-false-positives
     # Excluding configuration per-path, per-linter, per-text and per-source.
     rules:
-      - source: 'TODO'
-        linters: [ godot ]
-      - text: 'should have a package comment'
-        linters: [ revive ]
+      - source: "TODO"
+        linters: [godot]
+      - text: "should have a package comment"
+        linters: [revive]
       - text: 'exported \S+ \S+ should have comment( \(or a comment on this block\))? or be unexported'
-        linters: [ revive ]
+        linters: [revive]
       - text: 'package comment should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive ]
+        source: "// ?(nolint|TODO)"
+        linters: [revive]
       - text: 'comment on exported \S+ \S+ should be of the form ".+"'
-        source: '// ?(nolint|TODO)'
-        linters: [ revive, staticcheck ]
+        source: "// ?(nolint|TODO)"
+        linters: [revive, staticcheck]
       - path: '_test\.go'
         linters:
           - bodyclose
@@ -464,3 +464,6 @@ linters:
           - gosec
           - noctx
           - wrapcheck
+      - path: "engine-go/entrypoint/main.go"
+        linters:
+          - forbidigo

--- a/engine-go/entrypoint/main.go
+++ b/engine-go/entrypoint/main.go
@@ -43,7 +43,8 @@ func main() {
 	}
 
 	// Expected for an entrypoint.
-	// nosemgrep: dangerous-syscall-exec.
+	//nolint:gosec // This is expected for an entrypoint. No security issue, the user already control args and env variables.
+	// nosemgrep: dangerous-syscall-exec .
 	_ = syscall.Exec(binary, os.Args, os.Environ())
 }
 
@@ -63,7 +64,7 @@ func ChownRecursively(uid, gid int, root string) {
 	}
 	defer r.Close()
 
-	err = fs.WalkDir(r.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+	err = fs.WalkDir(r.FS(), ".", func(path string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			panic(err)
 		}

--- a/engine-go/entrypoint/main.go
+++ b/engine-go/entrypoint/main.go
@@ -41,8 +41,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	// nosemgrep: dangerous-syscall-exec.
+
 	// Expected for an entrypoint.
+	// nosemgrep: dangerous-syscall-exec.
 	_ = syscall.Exec(binary, os.Args, os.Environ())
 }
 

--- a/engine-go/entrypoint/main.go
+++ b/engine-go/entrypoint/main.go
@@ -2,9 +2,9 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"syscall"
 )
@@ -37,8 +37,13 @@ func main() {
 
 	DropAndSetNewPrivileges(uid, gid)
 
-	binary, _ := exec.LookPath("/app/jellyfin-newsletter")
-	syscall.Exec(binary, os.Args, os.Environ())
+	binary, err := exec.LookPath("/app/jellyfin-newsletter")
+	if err != nil {
+		panic(err)
+	}
+	// nosemgrep: dangerous-syscall-exec.
+	// Expected for an entrypoint.
+	_ = syscall.Exec(binary, os.Args, os.Environ())
 }
 
 func DropAndSetNewPrivileges(uid, gid int) {
@@ -50,21 +55,23 @@ func DropAndSetNewPrivileges(uid, gid int) {
 	}
 }
 
-// Source - https://stackoverflow.com/a/73864967
-// Posted by h0ch5tr4355
-// Retrieved 2026-04-16, License - CC BY-SA 4.0
 func ChownRecursively(uid, gid int, root string) {
-	err := filepath.Walk(root,
-		func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				panic(err)
-			}
-			err = os.Chown(path, uid, gid)
-			if err != nil {
-				panic(err)
-			}
-			return nil
-		})
+	r, err := os.OpenRoot(root)
+	if err != nil {
+		panic(err)
+	}
+	defer r.Close()
+
+	err = fs.WalkDir(r.FS(), ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			panic(err)
+		}
+		err = r.Lchown(path, uid, gid)
+		if err != nil {
+			panic(err)
+		}
+		return nil
+	})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Add a Go entrypoint that configures the filesystem permissions and then drops the privileges to run the script.
- Restore support of `USER_GID` and `USER_UID` env variables to configure the running user. This removes a BREAKING CHANGE introduced in beta 1.
- Fix #124