### PR TITLE
Feat/add support of poutine

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -156,7 +156,7 @@ jobs:
           echo "REPOSITORY_NAME=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/go_code_scan_test.yml
+++ b/.github/workflows/go_code_scan_test.yml
@@ -77,3 +77,18 @@ jobs:
         uses: golang/govulncheck-action@v1
         with:
           work-dir: engine-go/
+
+  poutine:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: poutine - GitHub Actions SAST
+        uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
+
+      - name: Upload poutine SARIF file
+        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7 # v4.35.4
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/go_code_scan_test.yml
+++ b/.github/workflows/go_code_scan_test.yml
@@ -89,6 +89,6 @@ jobs:
         uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
 
       - name: Upload poutine SARIF file
-        uses: github/codeql-action/upload-sarif@7434149006143a4d75b82a2f411ef15b03ccc2d7 # v4.35.4
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/go_code_scan_test.yml
+++ b/.github/workflows/go_code_scan_test.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: poutine - GitHub Actions SAST
-        uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
+        uses: boostsecurityio/poutine-action@v1.1.4 # v1.1.4
 
       - name: Upload poutine SARIF file
         uses: github/codeql-action/upload-sarif@v4


### PR DESCRIPTION
Add support of poutine security tools 

> Created by [BoostSecurity.io](https://boostsecurity.io/), poutine is a security scanner that detects misconfigurations and vulnerabilities in the build pipelines of a repository. It supports parsing CI workflows from GitHub Actions and Gitlab CI/CD. When given an access token with read-level access, poutine can analyze all the repositories of an organization to quickly gain insights into the security posture of the organization's software supply chain.

[fix(cicd): Bump actions/download-artifact from v4 to v8.0.1](https://github.com/SeaweedbrainCY/jellyfin-newsletter/commit/4774887f0a5a22de51a5d4c6b5f61a8402b547d8). v4 was impacted with known vulnerabilities

*Note: Poutine's detection related to python legacy pipeline are not addressed as the python code is about to be completely removed.*

