### PR TITLE
[Feat] Add local theme override

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ You can contribute to the translation of Jellyfin-Newsletter on [Weblate](https:
 </a>
 </p>
 
-### Create a new theme
+### Custom themes
+#### Create a new theme
 You can create and propose a new theme by following the [theme creation guide](engine-go/internal/template/themes/README.md).
 
 Currently available themes:
 - `Classic`
+
+#### Bring your own themes
+Jellyfin-Newsletter comes with built-in and embedded themes (listed above). However, before your new beautiful theme gets included in the official themes, you can just instruct Jellyfin-Newsletter to use a local theme file. 
+
+[Follow these instructions to use your own local theme files](https://github.com/SeaweedbrainCY/jellyfin-newsletter/wiki/Bring-your-own-themes)
+
 
 ## Recommended installation: Docker
 ### Requirements

--- a/engine-go/internal/config/loader.go
+++ b/engine-go/internal/config/loader.go
@@ -9,7 +9,7 @@ import (
 	"github.com/goccy/go-yaml"
 )
 
-func LoadConfig(configPath string) (*Configuration, error) {
+func LoadConfig(configPath string, themesDir string) (*Configuration, error) {
 	file, err := os.Open(configPath)
 	if err != nil {
 		return nil, err
@@ -19,7 +19,16 @@ func LoadConfig(configPath string) (*Configuration, error) {
 		return nil, err
 	}
 
+	conf.loadThemesDir(themesDir)
+
 	return conf, nil
+}
+
+func (conf *Configuration) loadThemesDir(themesDir string) {
+	if themesDir != "" {
+		fs := os.DirFS(themesDir)
+		conf.EmailTemplate.ThemesDirFS = &fs
+	}
 }
 
 func loadConfigFromReader(configPath string, r io.Reader) (*Configuration, error) {

--- a/engine-go/internal/config/model.go
+++ b/engine-go/internal/config/model.go
@@ -1,5 +1,7 @@
 package config
 
+import "io/fs"
+
 type LogConfig struct {
 	Level  string
 	Format string
@@ -34,6 +36,7 @@ type EmailTemplateConfig struct {
 	JellyfinOwnerName       string
 	DisplayOverviewMaxItems int
 	SortMode                string
+	ThemesDirFS             *fs.FS
 }
 
 type SMTPConfig struct {

--- a/engine-go/internal/newsletter/newsletter_integration_test.go
+++ b/engine-go/internal/newsletter/newsletter_integration_test.go
@@ -73,7 +73,7 @@ func initApp(t *testing.T) (*app.ApplicationContext, *observer.ObservedLogs, err
 	if configPath == "" {
 		t.Fatal("INTEGRATION_TEST_CONFIG_FILE is not defined")
 	}
-	config, err := config.LoadConfig(configPath)
+	config, err := config.LoadConfig(configPath, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -113,12 +113,17 @@ func getNewMediaHTMLTemplate(
 			app.Config.EmailTemplate.Theme,
 			filename,
 		)
-		tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filePath)
+		tmpl, err := template.New(filename).
+			Option("missingkey=zero").
+			ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filePath)
 		if err == nil {
 			return tmpl, nil
 		}
 		// else defaulting to embedded themeFS
-		app.Logger.Warn("Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.", zap.String("filePath", filePath))
+		app.Logger.Warn(
+			"Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.",
+			zap.String("filePath", filePath),
+		)
 	}
 
 	filePath := filepath.Join(

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -96,28 +96,37 @@ type footerTemplateData struct {
 var templateHTMLThemesFS embed.FS
 
 func CheckIfThemeIsAvailable(app *app.ApplicationContext) error {
-	filePath := filepath.Join(
-		"themes",
-		app.Config.EmailTemplate.Theme,
-		app.Config.EmailTemplate.Theme+".html",
-	)
-	if _, err := template.ParseFS(templateHTMLThemesFS, filePath); err != nil {
+	if _, err := getNewMediaHTMLTemplate(templateHTMLThemesFS, app); err != nil {
 		return err
 	}
 	return nil
 }
 
 func getNewMediaHTMLTemplate(
-	themeFS embed.FS,
+	defaultThemeFS embed.FS,
 	app *app.ApplicationContext,
 ) (*template.Template, error) {
 	filename := app.Config.EmailTemplate.Theme + ".html"
+	if app.Config.EmailTemplate.ThemesDirFS != nil {
+		// If the theme is available in the provided themes dir, it will be choosen. If the is not found in this dir, it will default to default embedded theme dir.
+		filePath := filepath.Join(
+			app.Config.EmailTemplate.Theme,
+			filename,
+		)
+		tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filePath)
+		if err != nil {
+			return tmpl, nil
+		}
+		// else defaulting to embedded themeFS
+		app.Logger.Warn("Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.", zap.String("filePath", filePath))
+	}
+
 	filePath := filepath.Join(
 		"themes",
 		app.Config.EmailTemplate.Theme,
 		filename,
 	)
-	tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(themeFS, filePath)
+	tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(defaultThemeFS, filePath)
 
 	if err != nil {
 		app.Logger.Error(

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -5,6 +5,7 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net/url"
 	"path/filepath"
 	"slices"
@@ -109,20 +110,24 @@ func getNewMediaHTMLTemplate(
 	filename := app.Config.EmailTemplate.Theme + ".html"
 	if app.Config.EmailTemplate.ThemesDirFS != nil {
 		// If the theme is available in the provided themes dir, it will be choosen. If the is not found in this dir, it will default to default embedded theme dir.
-		filePath := filepath.Join(
-			app.Config.EmailTemplate.Theme,
-			filename,
-		)
 		tmpl, err := template.New(filename).
 			Option("missingkey=zero").
-			ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filePath)
+			ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filename)
 		if err == nil {
 			return tmpl, nil
 		}
 		// else defaulting to embedded themeFS
+		// Log available files for troubleshooting
+		var availableFiles []string
+		fs.WalkDir(*app.Config.EmailTemplate.ThemesDirFS, ".", func(path string, d fs.DirEntry, err error) error {
+			if err == nil && !d.IsDir() {
+				availableFiles = append(availableFiles, path)
+			}
+			return nil
+		})
 		app.Logger.Warn(
 			"Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.",
-			zap.String("filePath", filePath),
+			zap.String("filePath", filename), zap.Strings("availableFiles", availableFiles), zap.Error(err),
 		)
 	}
 
@@ -134,10 +139,19 @@ func getNewMediaHTMLTemplate(
 	tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(defaultThemeFS, filePath)
 
 	if err != nil {
+		// Log available files for troubleshooting
+		var availableFiles []string
+		fs.WalkDir(defaultThemeFS, ".", func(path string, d fs.DirEntry, err error) error {
+			if err == nil && !d.IsDir() {
+				availableFiles = append(availableFiles, path)
+			}
+			return nil
+		})
 		app.Logger.Error(
-			"Impossible to open the template file. Email HTML building will fail.",
+			"Theme is not availabke. Impossible to open the template file. Email HTML building will fail.",
 			zap.String("filePath", filePath),
 			zap.Error(err),
+			zap.Strings("availableFiles", availableFiles),
 		)
 		return nil, err
 	}

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -119,12 +119,17 @@ func getNewMediaHTMLTemplate(
 		// else defaulting to embedded themeFS
 		// Log available files for troubleshooting
 		var availableFiles []string
-		fs.WalkDir(*app.Config.EmailTemplate.ThemesDirFS, ".", func(path string, d fs.DirEntry, err error) error {
-			if err == nil && !d.IsDir() {
-				availableFiles = append(availableFiles, path)
-			}
-			return nil
-		})
+		walkDirErr := fs.WalkDir(
+			*app.Config.EmailTemplate.ThemesDirFS,
+			".",
+			func(path string, d fs.DirEntry, err error) error {
+				if err == nil && !d.IsDir() {
+					availableFiles = append(availableFiles, path)
+				}
+				return nil
+			},
+		)
+		availableFiles = append(availableFiles, walkDirErr.Error())
 		app.Logger.Warn(
 			"Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.",
 			zap.String("filePath", filename), zap.Strings("availableFiles", availableFiles), zap.Error(err),
@@ -141,12 +146,13 @@ func getNewMediaHTMLTemplate(
 	if err != nil {
 		// Log available files for troubleshooting
 		var availableFiles []string
-		fs.WalkDir(defaultThemeFS, ".", func(path string, d fs.DirEntry, err error) error {
+		walkDirErr := fs.WalkDir(defaultThemeFS, ".", func(path string, d fs.DirEntry, err error) error {
 			if err == nil && !d.IsDir() {
 				availableFiles = append(availableFiles, path)
 			}
 			return nil
 		})
+		availableFiles = append(availableFiles, walkDirErr.Error())
 		app.Logger.Error(
 			"Theme is not availabke. Impossible to open the template file. Email HTML building will fail.",
 			zap.String("filePath", filePath),

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -114,7 +114,7 @@ func getNewMediaHTMLTemplate(
 			filename,
 		)
 		tmpl, err := template.New(filename).Option("missingkey=zero").ParseFS(*app.Config.EmailTemplate.ThemesDirFS, filePath)
-		if err != nil {
+		if err == nil {
 			return tmpl, nil
 		}
 		// else defaulting to embedded themeFS

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -129,7 +129,9 @@ func getNewMediaHTMLTemplate(
 				return nil
 			},
 		)
-		availableFiles = append(availableFiles, walkDirErr.Error())
+		if walkDirErr != nil {
+			availableFiles = append(availableFiles, walkDirErr.Error())
+		}
 		app.Logger.Warn(
 			"Theme not found in custom theme directory. Will default to default Jellyfin-Newsletter themes.",
 			zap.String("filePath", filename), zap.Strings("availableFiles", availableFiles), zap.Error(err),
@@ -152,7 +154,10 @@ func getNewMediaHTMLTemplate(
 			}
 			return nil
 		})
-		availableFiles = append(availableFiles, walkDirErr.Error())
+		if walkDirErr != nil {
+			availableFiles = append(availableFiles, walkDirErr.Error())
+		}
+
 		app.Logger.Error(
 			"Theme is not availabke. Impossible to open the template file. Email HTML building will fail.",
 			zap.String("filePath", filePath),

--- a/engine-go/internal/template/builder_test.go
+++ b/engine-go/internal/template/builder_test.go
@@ -735,7 +735,11 @@ func TestBuildNewMediaEmailHTMLWithCustomDirTheme(t *testing.T) {
 		assert.Contains(t, unescapedHTML, series.Overview)
 		assert.Contains(t, unescapedHTML, series.NewSeriesTitle)
 	}
-	assert.Contains(t, unescapedHTML, "This is a test theme template without stat section. If you can read this, it worked")
+	assert.Contains(
+		t,
+		unescapedHTML,
+		"This is a test theme template without stat section. If you can read this, it worked",
+	)
 }
 
 func TestBuildNewMediaEmailHTMLWithThemeFallBack(t *testing.T) {

--- a/engine-go/internal/template/builder_test.go
+++ b/engine-go/internal/template/builder_test.go
@@ -2,7 +2,10 @@ package template
 
 import (
 	"html"
+	"os"
+	"regexp"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -676,4 +679,79 @@ func TestBuildNewMediaEmailHTML(t *testing.T) {
 		assert.Contains(t, unescapedHTML, series.Overview)
 		assert.Contains(t, unescapedHTML, series.NewSeriesTitle)
 	}
+}
+
+func TestBuildNewMediaEmailHTMLWithCustomDirTheme(t *testing.T) {
+	newMovies := getJellyfinNewMovies()
+	newSeries := getJellyfinNewSeriesItems()
+	movieCount := int32(1254)
+	seriesCount := int32(1253)
+	app, _ := getAppContext()
+	dirFS := os.DirFS("../../testdata/themes/")
+	app.Config.EmailTemplate.ThemesDirFS = &dirFS
+	app.Config.EmailTemplate.Theme = "custom_theme1"
+	expectedTemplateData := getExpectedNewMediaTemplateData()
+
+	escapedHTML, err := BuildNewMediaEmailHTML(&newMovies, &newSeries, movieCount, seriesCount, app)
+	unescapedHTML := html.UnescapeString(escapedHTML)
+
+	// collapse multi spaces
+	var multiSpace = regexp.MustCompile(`\s+`)
+	unescapedHTML = strings.TrimSpace(multiSpace.ReplaceAllString(unescapedHTML, " "))
+
+	require.NoError(t, err)
+
+	assert.NotContains(t, unescapedHTML, "{{")
+	assert.NotContains(t, unescapedHTML, "}}")
+	assert.Contains(t, unescapedHTML, expectedTemplateData.HTMLLang)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.HTMLDir)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.Title)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.Subtitle)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.JellyfinURL)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.DiscoverNowLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.NewFilmLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.NewSeriesLabel)
+	assert.NotContains(t, unescapedHTML, expectedTemplateData.CurrentlyAvailableLabel)
+	assert.NotContains(t, unescapedHTML, movieCount)
+	assert.NotContains(t, unescapedHTML, seriesCount)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterProjectLinkLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterOpenSourceProjectLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterDevelopedByLabel)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterLicenceAndCopyright)
+	for _, movies := range expectedTemplateData.NewMovies {
+		assert.Contains(t, unescapedHTML, movies.PosterURL)
+		assert.Contains(t, unescapedHTML, movies.Name)
+		assert.Contains(t, unescapedHTML, movies.AddedOnLabel)
+		assert.Contains(t, unescapedHTML, movies.AdditionDate)
+		assert.Contains(t, unescapedHTML, movies.Overview)
+	}
+
+	for _, series := range expectedTemplateData.NewSeries {
+		assert.Contains(t, unescapedHTML, series.PosterURL)
+		assert.Contains(t, unescapedHTML, series.SeriesName)
+		assert.Contains(t, unescapedHTML, series.AddedOnLabel)
+		assert.Contains(t, unescapedHTML, series.AdditionDate)
+		assert.Contains(t, unescapedHTML, series.Overview)
+		assert.Contains(t, unescapedHTML, series.NewSeriesTitle)
+	}
+	assert.Contains(t, unescapedHTML, "This is a test theme template without stat section. If you can read this, it worked")
+}
+
+func TestBuildNewMediaEmailHTMLWithThemeFallBack(t *testing.T) {
+	newMovies := getJellyfinNewMovies()
+	newSeries := getJellyfinNewSeriesItems()
+	movieCount := int32(54)
+	seriesCount := int32(1253)
+	app, _ := getAppContext()
+	expectedTemplateData := getExpectedNewMediaTemplateData()
+	dirFS := os.DirFS("../../testdata/themes/")
+	app.Config.EmailTemplate.ThemesDirFS = &dirFS
+	app.Config.EmailTemplate.Theme = "classic"
+
+	escapedHTML, err := BuildNewMediaEmailHTML(&newMovies, &newSeries, movieCount, seriesCount, app)
+	unescapedHTML := html.UnescapeString(escapedHTML)
+
+	require.NoError(t, err)
+	assert.Contains(t, unescapedHTML, expectedTemplateData.Subtitle)
 }

--- a/engine-go/main.go
+++ b/engine-go/main.go
@@ -23,9 +23,10 @@ var version = "dev" // Will be set during build time
 
 func main() {
 	var configPath = flag.String("config", "./config/config.yml", "path to config file")
+	var themesDir = flag.String("themes-dir", "", "path to a folder with new/replacing themes files")
 	flag.Parse()
 
-	config, err := config.LoadConfig(*configPath)
+	config, err := config.LoadConfig(*configPath, *themesDir)
 	if err != nil {
 		panic(fmt.Sprintf("Failed to load configuration: %v", err))
 	}

--- a/engine-go/testdata/themes/custom_theme1.html
+++ b/engine-go/testdata/themes/custom_theme1.html
@@ -1,0 +1,638 @@
+<!--
+Template: Classic
+-->
+
+<!doctype html>
+<html lang="{{.HTMLLang}}" dir="{{.HTMLDir}}">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+        <!-- Gmail-specific meta tags -->
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+        <meta name="format-detection" content="telephone=no" />
+        <meta name="format-detection" content="date=no" />
+        <meta name="format-detection" content="address=no" />
+        <meta name="format-detection" content="email=no" />
+        <style>
+            /* Reset for email clients */
+            body,
+            table,
+            td,
+            p,
+            a,
+            h1,
+            h2,
+            h3 {
+                font-family: Arial, Helvetica, sans-serif;
+                -webkit-text-size-adjust: 100%;
+                -ms-text-size-adjust: 100%;
+                color: #ffffff !important;
+            }
+
+            body {
+                background: #000011;
+                margin: 0;
+                padding: 0;
+            }
+
+            .container {
+                max-width: 600px;
+                margin: 0 auto;
+            }
+
+            .main-table {
+                width: 100%;
+                max-width: 600px;
+                border-collapse: collapse;
+                margin: 0 auto;
+            }
+
+            .content-cell {
+                padding: 15px;
+            }
+
+            .title {
+                text-align: center;
+                padding: 20px 0;
+            }
+
+            h1 {
+                color: #00ccff !important;
+                font-size: 24px !important;
+                margin: 0 0 10px !important;
+            }
+
+            p {
+                font-size: 16px !important;
+                line-height: 1.4 !important;
+                margin: 0 0 15px !important;
+                color: #dddddd !important;
+            }
+
+            .button {
+                background-color: #00ccff;
+                color: #ffffff !important;
+                display: inline-block;
+                padding: 12px 25px;
+                text-decoration: none;
+                border-radius: 5px;
+                font-size: 16px;
+                font-weight: bold;
+                margin: 10px 0;
+            }
+
+            .movie-container {
+                border-radius: 10px;
+                overflow: hidden;
+                margin-bottom: 15px;
+            }
+
+            .movie_bg {
+                background-size: cover;
+                background-position: center;
+                border-radius: 10px;
+            }
+
+            .movie {
+                background: rgba(0, 0, 0, 0.7);
+                border-radius: 10px;
+                width: 100%;
+                border-collapse: collapse;
+            }
+
+            .movie-card {
+                background: rgba(0, 0, 0, 0.7);
+                border: 1px solid #444;
+                border-radius: 10px;
+                margin: 0 0 15px;
+                overflow: hidden;
+            }
+
+            .movie-content {
+                padding: 15px;
+            }
+
+            .movie-image {
+                text-align: center;
+                padding: 15px;
+                width: 120px;
+            }
+
+            .movie-image img {
+                max-width: 100px;
+                height: auto;
+                display: block;
+                margin: 0 auto;
+            }
+
+            .movie-title {
+                font-size: 18px !important;
+                margin: 0 0 5px !important;
+                color: #ffffff !important;
+            }
+
+            .movie-date {
+                color: #dddddd !important;
+                font-size: 14px !important;
+                margin: 0 0 10px !important;
+            }
+
+            .movie-description {
+                font-size: 14px !important;
+                line-height: 1.4 !important;
+                color: #dddddd !important;
+                word-wrap: break-word !important;
+                overflow-wrap: break-word !important;
+                max-width: 100% !important;
+                word-break: break-word !important;
+            }
+
+            .section-title {
+                color: #00ccff !important;
+                font-size: 20px !important;
+                padding: 10px 15px;
+            }
+
+            .stats-table {
+                width: 100%;
+                border-collapse: collapse;
+                margin: 20px 0;
+                text-align: center;
+            }
+
+            .stats-cell {
+                padding: 15px;
+                width: 50%;
+            }
+
+            .stats-number {
+                font-size: 28px !important;
+                margin: 0 0 5px !important;
+                color: #00ccff !important;
+            }
+
+            .stats-label {
+                font-size: 14px !important;
+                color: #dddddd !important;
+            }
+
+            .divider {
+                border-top: 1px solid #333;
+                margin: 30px 0;
+            }
+
+            footer {
+                text-align: center;
+                padding: 20px 0;
+                font-size: 12px !important;
+                color: #aaaaaa !important;
+            }
+
+            .footer-link,
+            .footer-link:visited {
+                color: #4287f5 !important;
+                text-decoration: underline !important;
+            }
+
+            /* Gmail-specific fixes */
+            u + .body a {
+                color: inherit !important;
+                text-decoration: none !important;
+                font-size: inherit !important;
+                font-family: inherit !important;
+                font-weight: inherit !important;
+                line-height: inherit !important;
+            }
+
+            /* Mobile spacing container */
+            .mobile-text-container {
+                /* No changes needed for desktop */
+            }
+
+            /* Mobile-specific spacing */
+            @media screen and (max-width: 600px) {
+                .mobile-text-container {
+                    margin-top: 20px;
+                    /* Increased space above text */
+                }
+
+                .movie-image {
+                    padding-bottom: 0 !important;
+                }
+
+                .movie-content-cell {
+                    padding-top: 5px !important;
+                    /* Reduced cell padding */
+                    padding-left: 15px !important;
+                    padding-right: 15px !important;
+                }
+            }
+
+            /* RTL adjustments */
+            [dir="rtl"] h1,
+            [dir="rtl"] h2,
+            [dir="rtl"] p,
+            [dir="rtl"] .movie-date,
+            [dir="rtl"] .movie-description,
+            [dir="rtl"] .section-title {
+                text-align: right !important;
+            }
+
+            /* Keep title section centered even in RTL */
+            [dir="rtl"] .title h1,
+            [dir="rtl"] .title p {
+                text-align: center !important;
+            }
+
+            /* Keep stats section title centered even in RTL */
+            [dir="rtl"] h2[style*="text-align: center"] {
+                text-align: center !important;
+            }
+
+            [dir="rtl"] .movie-content-cell {
+                direction: rtl !important;
+            }
+
+            /* RTL row ordering - reverse content and image cells */
+            [dir="rtl"] .movie-row {
+                display: flex !important;
+                flex-direction: row-reverse !important;
+            }
+
+            [dir="rtl"] .movie-row td {
+                display: block !important;
+            }
+
+            /* Specific RTL footer handling - keep center alignment but RTL direction */
+            [dir="rtl"] footer {
+                text-align: center !important;
+                direction: rtl !important;
+            }
+
+            [dir="rtl"] footer p {
+                direction: rtl !important;
+            }
+
+            /* Media Queries */
+            @media screen and (max-width: 600px) {
+                .movie-card-table {
+                    display: block !important;
+                    width: 100% !important;
+                }
+
+                .movie-image,
+                .movie-content-cell {
+                    display: block !important;
+                    width: 100% !important;
+                    text-align: center !important;
+                    padding: 10px !important;
+                    box-sizing: border-box;
+                }
+
+                .movie-image {
+                    padding-bottom: 0 !important;
+                }
+
+                .movie-image img {
+                    margin: 0 auto !important;
+                }
+
+                .movie-content-cell {
+                    padding-top: 0 !important;
+                    padding-left: 15px !important;
+                    padding-right: 15px !important;
+                }
+
+                .movie-description {
+                    font-size: 13px !important;
+                }
+
+                .movie_container {
+                    margin: 0 10px 15px;
+                }
+
+                .main-table {
+                    width: 100% !important;
+                }
+
+                .content-cell {
+                    padding: 10px !important;
+                }
+            }
+        </style>
+    </head>
+
+    <body>
+        <!-- Hidden content to prevent Gmail clipping -->
+        <div style="display: none; max-height: 0px; overflow: hidden"></div>
+
+        <center>
+            <table
+                class="main-table"
+                role="presentation"
+                cellpadding="0"
+                cellspacing="0"
+                width="100%"
+            >
+                <tr>
+                    <td class="content-cell" bgcolor="#000011">
+                        <!-- Title Section -->
+                        <table
+                            width="100%"
+                            role="presentation"
+                            cellpadding="0"
+                            cellspacing="0"
+                        >
+                            <tr>
+                                <td class="title" style="text-align: center">
+                                    <h1>{{.Title}}</h1>
+                                    <p>{{.Subtitle}}</p>
+                                    <br />
+                                    <a href="{{.JellyfinURL}}" class="button"
+                                        >{{.DiscoverNowLabel}}</a
+                                    >
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- Movies Section -->
+                        {{if .DisplayNewMovies}}
+                        <div>
+                            <h2 class="section-title">{{.NewFilmLabel}}</h2>
+                            <div class="movie-container">
+                                {{range .NewMovies}}
+                                <a
+                                    href="{{.MediaURL}}"
+                                    style="text-decoration: none"
+                                >
+                                    <div
+                                        class="movie_container"
+                                        style="margin-bottom: 15px"
+                                    >
+                                        <div
+                                            class="movie_bg"
+                                            style="background: url('{{.PosterURL}}') no-repeat center center; background-size: cover; border-radius: 10px;"
+                                        >
+                                            <table
+                                                class="movie"
+                                                width="100%"
+                                                role="presentation"
+                                                cellpadding="0"
+                                                cellspacing="0"
+                                                style="
+                                                    background: rgba(
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0.7
+                                                    );
+                                                    border-radius: 10px;
+                                                    width: 100%;
+                                                "
+                                            >
+                                                <tr>
+                                                    <td
+                                                        class="movie-image"
+                                                        valign="middle"
+                                                        style="
+                                                            padding: 15px;
+                                                            text-align: center;
+                                                            width: 120px;
+                                                        "
+                                                    >
+                                                        <img
+                                                            src="{{.PosterURL}}"
+                                                            alt="{{.Name}}"
+                                                            style="
+                                                                max-width: 100px;
+                                                                height: auto;
+                                                                display: block;
+                                                                margin: 0 auto;
+                                                            "
+                                                        />
+                                                    </td>
+                                                    <td
+                                                        class="movie-content-cell"
+                                                        valign="middle"
+                                                        style="padding: 15px"
+                                                    >
+                                                        <div
+                                                            class="mobile-text-container"
+                                                        >
+                                                            <h3
+                                                                class="movie-title"
+                                                                style="
+                                                                    color: #ffffff !important;
+                                                                    margin: 0 0
+                                                                        5px !important;
+                                                                    font-size: 18px !important;
+                                                                "
+                                                            >
+                                                                {{.Name}}
+                                                            </h3>
+                                                            <div
+                                                                class="movie-date"
+                                                                style="
+                                                                    color: #dddddd !important;
+                                                                    font-size: 14px !important;
+                                                                    margin: 0 0
+                                                                        10px !important;
+                                                                "
+                                                            >
+                                                                {{.AddedOnLabel}}
+                                                                {{.AdditionDate}}
+                                                            </div>
+                                                            {{if
+                                                            .IncludeItemOverviews}}
+                                                            <div
+                                                                class="movie-description"
+                                                                style="
+                                                                    color: #dddddd !important;
+                                                                    font-size: 14px !important;
+                                                                    line-height: 1.4 !important;
+                                                                "
+                                                            >
+                                                                {{.Overview}}
+                                                            </div>
+                                                            {{end}}
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </a>
+                                {{end}}
+                            </div>
+                        </div>
+                        {{end}} {{if .DisplayNewSeries}}
+                        <!-- TV Shows Section -->
+                        <div>
+                            <h2 class="section-title">{{.NewSeriesLabel}}</h2>
+                            <div class="movie-container">
+                                {{range .NewSeries}}
+                                <a
+                                    href="{{.MediaURL}}"
+                                    style="text-decoration: none"
+                                >
+                                    <div
+                                        class="movie_container"
+                                        style="margin-bottom: 15px"
+                                    >
+                                        <div
+                                            class="movie_bg"
+                                            style="background: url('{{.PosterURL}}') no-repeat center center; background-size: cover; border-radius: 10px;"
+                                        >
+                                            <table
+                                                class="movie"
+                                                width="100%"
+                                                role="presentation"
+                                                cellpadding="0"
+                                                cellspacing="0"
+                                                style="
+                                                    background: rgba(
+                                                        0,
+                                                        0,
+                                                        0,
+                                                        0.7
+                                                    );
+                                                    border-radius: 10px;
+                                                    width: 100%;
+                                                "
+                                            >
+                                                <tr>
+                                                    <td
+                                                        class="movie-image"
+                                                        valign="middle"
+                                                        style="
+                                                            padding: 15px;
+                                                            text-align: center;
+                                                            width: 120px;
+                                                        "
+                                                    >
+                                                        <img
+                                                            src="{{.PosterURL}}"
+                                                            alt="{{.SeriesName}}"
+                                                            style="
+                                                                max-width: 100px;
+                                                                height: auto;
+                                                                display: block;
+                                                                margin: 0 auto;
+                                                            "
+                                                        />
+                                                    </td>
+                                                    <td
+                                                        class="movie-content-cell"
+                                                        valign="middle"
+                                                        style="padding: 15px"
+                                                    >
+                                                        <div
+                                                            class="mobile-text-container"
+                                                        >
+                                                            <h3
+                                                                class="movie-title"
+                                                                style="
+                                                                    color: #ffffff !important;
+                                                                    margin: 0 0
+                                                                        5px !important;
+                                                                    font-size: 18px !important;
+                                                                "
+                                                            >
+                                                                {{.NewSeriesTitle}}
+                                                            </h3>
+                                                            <div
+                                                                class="movie-date"
+                                                                style="
+                                                                    color: #dddddd !important;
+                                                                    font-size: 14px !important;
+                                                                    margin: 0 0
+                                                                        10px !important;
+                                                                "
+                                                            >
+                                                                {{.AddedOnLabel}}
+                                                                {{.AdditionDate}}
+                                                            </div>
+                                                            {{if
+                                                            .IncludeItemOverviews}}
+                                                            <div
+                                                                class="movie-description"
+                                                                style="
+                                                                    color: #dddddd !important;
+                                                                    font-size: 14px !important;
+                                                                    line-height: 1.4 !important;
+                                                                "
+                                                            >
+                                                                {{.Overview}}
+                                                            </div>
+                                                            {{end}}
+                                                        </div>
+                                                    </td>
+                                                </tr>
+                                            </table>
+                                        </div>
+                                    </div>
+                                </a>
+                                {{end}}
+                            </div>
+                        </div>
+                        {{end}}
+
+                        <h2>
+                            This is a test theme template without stat section.
+                            If you can read this, it worked
+                        </h2>
+
+                        <!-- Footer -->
+                        <footer>
+                            {{.FooterLabel}}
+                            <br /><br /><br />
+
+                            <!--
+                            BEFORE EDITING ANYTHING BELOW THIS LINE, PLEASE READ THE FOLLOWING:
+                            While the AGPLv3 license allows modification and redistribution, I kindly ask that the footer attribution remain intact to acknowledge the original project and its contributors. This helps support the open-source community and gives credit where it's due.
+
+                            Thanks !
+                        -->
+                            <a
+                                href="https://github.com/SeaweedbrainCY/jellyfin-newsletter"
+                                class="footer-link"
+                                >{{.FooterProjectLinkLabel}}</a
+                            >
+                            {{.FooterOpenSourceProjectLabel}}
+                            <bdi
+                                >{{.FooterDevelopedByLabel}}
+                                <a
+                                    href="https://github.com/SeaweedbrainCY/"
+                                    class="footer-link"
+                                    >SeaweedbrainCY</a
+                                >
+                                {{.AndLocalized}}
+                                <a
+                                    href="https://github.com/seaweedbraincy/jellyfin-newsletter/graphs/contributors"
+                                    class="footer-link"
+                                    >{{.TheContributorsLabel}}</a
+                                >.</bdi
+                            >
+                            <br />
+                            {{.FooterLicenceAndCopyright}}
+                        </footer>
+                    </td>
+                </tr>
+            </table>
+        </center>
+
+        <!-- Prevent Gmail clipping -->
+        <div
+            style="
+                display: none;
+                white-space: nowrap;
+                font: 15px courier;
+                line-height: 0;
+            "
+        >
+            &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+            &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
- Add the ability to mount and define a local directory to override themes folder. User will be able to drop and use theme from this directory 
- Docs has been added at https://github.com/SeaweedbrainCY/jellyfin-newsletter/wiki/Bring-your-own-themes and in the readme 
- Tests have been added to cover this point
- Fix #137 