### PR TITLE
fix: Use JellyfinURL instead of jellyfin's URL given for API usage

### DIFF
--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -439,7 +439,7 @@ func buildNewMediaTemplateData(
 	displayMovieOverviews := shouldOverviewsBeDisplayed(len(newJellyfinMoviesSorted), app)
 	displaySeriesOverviews := shouldOverviewsBeDisplayed(len(newJellyfinSeriesSorted), app)
 
-	jellyfinParsedURL, _ := url.Parse(app.Config.Jellyfin.URL)
+	jellyfinParsedURL, _ := url.Parse(app.Config.EmailTemplate.JellyfinURL)
 
 	for _, newMovieItem := range newJellyfinMoviesSorted {
 		newMoviesData = append(newMoviesData, newMovieItemTemplateData{


### PR DESCRIPTION
fix #150