### PR TITLE
Feat/add max displayed item limit

### DIFF
--- a/config/config-example.yml
+++ b/config/config-example.yml
@@ -67,6 +67,11 @@ email_template:
   # Always hide summaries : set to -1
   #display_overview_max_items: 10
 
+  # OPTIONAL: Maximum items displayed in the email.
+  # If there is more items than this number, the first x items will be displayed and a '... and y more' will be added
+  # Comment out the line to disable this feature
+  #max_displayed_items: 10
+
   # OPTIONAL: Sorting mode for items in the email
   # Allowed values: "date_asc" (default), "date_desc", "name_asc", "name_desc"
   # - date_asc: sort by date (oldest first)

--- a/engine-go/internal/config/loader.go
+++ b/engine-go/internal/config/loader.go
@@ -127,6 +127,7 @@ func buildTMDBConfig(yamlParsedConfig *yamlConfiguration) TMDBConfig {
 
 func buildEmailTemplateConfig(yamlParsedConfig *yamlConfiguration) EmailTemplateConfig {
 	const defaultDisplayOverviewMaxItem int = 10
+	const defaultMaxDisplayedItems int = 0 // no limit
 
 	emailTemplateConfig := EmailTemplateConfig{
 		Language:                yamlParsedConfig.EmailTemplate.Language,
@@ -136,6 +137,7 @@ func buildEmailTemplateConfig(yamlParsedConfig *yamlConfiguration) EmailTemplate
 		JellyfinURL:             yamlParsedConfig.EmailTemplate.JellyfinURL,
 		UnsubscribeEmail:        yamlParsedConfig.EmailTemplate.UnsubscribeEmail,
 		JellyfinOwnerName:       yamlParsedConfig.EmailTemplate.JellyfinOwnerName,
+		MaxDisplayedItems:       defaultMaxDisplayedItems,
 		Theme:                   "classic",
 		DisplayOverviewMaxItems: defaultDisplayOverviewMaxItem,
 		SortMode:                "date_desc",
@@ -148,6 +150,10 @@ func buildEmailTemplateConfig(yamlParsedConfig *yamlConfiguration) EmailTemplate
 
 	if yamlParsedConfig.EmailTemplate.DisplayOverviewMaxItems != nil {
 		emailTemplateConfig.DisplayOverviewMaxItems = *yamlParsedConfig.EmailTemplate.DisplayOverviewMaxItems
+	}
+
+	if yamlParsedConfig.EmailTemplate.MaxDisplayedItems != nil {
+		emailTemplateConfig.MaxDisplayedItems = *yamlParsedConfig.EmailTemplate.MaxDisplayedItems
 	}
 
 	if yamlParsedConfig.EmailTemplate.SortMode != "" {

--- a/engine-go/internal/config/model.go
+++ b/engine-go/internal/config/model.go
@@ -37,6 +37,7 @@ type EmailTemplateConfig struct {
 	DisplayOverviewMaxItems int
 	SortMode                string
 	ThemesDirFS             *fs.FS
+	MaxDisplayedItems       int
 }
 
 type SMTPConfig struct {
@@ -99,6 +100,7 @@ type yamlConfiguration struct {
 		JellyfinOwnerName       string `yaml:"jellyfin_owner_name,omitempty"`
 		DisplayOverviewMaxItems *int   `yaml:"display_overview_max_items,omitempty" validate:"omitempty,numeric,min=-1"`
 		SortMode                string `yaml:"sort_mode,omitempty" validate:"omitempty,oneof=date_desc date_asc name_asc name_desc"`
+		MaxDisplayedItems       *int   `yaml:"max_displayed_items,omitempty" validate:"omitempty,numeric,min=0"`
 	} `yaml:"email_template"      validate:"required"`
 	Email struct {
 		SMTPServer     string `yaml:"smtp_server" validate:"required,hostname|ip"`

--- a/engine-go/internal/i18n/active.en.toml
+++ b/engine-go/internal/i18n/active.en.toml
@@ -46,6 +46,13 @@ other = "the contributors"
 [license_and_copyright]
 other = "Copyright © 2025 Nathan Stchepinsky, licensed under AGPLv3."
 
+[and_more_titles_prefix_label]
+other = "... and"
+
+[and_more_titles_suffix_label]
+one = "more title!"
+other = "more titles!"
+
 [monday]
 other = "Monday"
 

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -47,30 +47,35 @@ type newSeriesItemTemplateData struct {
 }
 
 type newMediaTemplateData struct {
-	HTMLLang                     string
-	HTMLDir                      string
-	Title                        string
-	Subtitle                     string
-	JellyfinURL                  string
-	DiscoverNowLabel             string
-	DisplayNewMovies             bool
-	NewFilmLabel                 string
-	NewMovies                    []newMovieItemTemplateData
-	DisplayNewSeries             bool
-	NewSeriesLabel               string
-	NewSeries                    []newSeriesItemTemplateData
-	CurrentlyAvailableLabel      string
-	MoviesCount                  string
-	MoviesLabel                  string
-	SeriesCount                  string
-	SeriesLabel                  string
-	FooterLabel                  string
-	FooterProjectLinkLabel       string
-	FooterOpenSourceProjectLabel string
-	FooterDevelopedByLabel       string
-	FooterLicenceAndCopyright    string
-	AndLocalized                 string
-	TheContributorsLabel         string
+	HTMLLang                         string
+	HTMLDir                          string
+	Title                            string
+	Subtitle                         string
+	JellyfinURL                      string
+	DiscoverNowLabel                 string
+	DisplayNewMovies                 bool
+	NewFilmLabel                     string
+	NewMovies                        []newMovieItemTemplateData
+	RemainingMoviesNotDisplayedCount int // #151. If 0, all movies are displayed
+	DisplayNewSeries                 bool
+	NewSeriesLabel                   string
+	NewSeries                        []newSeriesItemTemplateData
+	RemainingSeriesNotDisplayedCount int // #151. If 0, all series are displayed
+	CurrentlyAvailableLabel          string
+	MoviesCount                      string
+	MoviesLabel                      string
+	SeriesCount                      string
+	SeriesLabel                      string
+	FooterLabel                      string
+	FooterProjectLinkLabel           string
+	FooterOpenSourceProjectLabel     string
+	FooterDevelopedByLabel           string
+	FooterLicenceAndCopyright        string
+	AndLocalized                     string
+	TheContributorsLabel             string
+	AndMoreTitlesPrefixLabel         string
+	AndMoreTitlesSuffixLabelSeries   string
+	AndMoreTitlesSuffixLabelMovies   string
 }
 
 type titlePlaceholders struct {
@@ -441,7 +446,11 @@ func buildNewMediaTemplateData(
 
 	jellyfinParsedURL, _ := url.Parse(app.Config.Jellyfin.URL)
 
-	for _, newMovieItem := range newJellyfinMoviesSorted {
+	for i, newMovieItem := range newJellyfinMoviesSorted {
+		if app.Config.EmailTemplate.MaxDisplayedItems != 0 && i >= app.Config.EmailTemplate.MaxDisplayedItems {
+			app.Logger.Debug("MaxDisplayedItems setting reached. Next new items will be ignored.", zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems), zap.Int("newJellyfinMoviesSorted count", len(newJellyfinMoviesSorted)), zap.String("type", "movies"))
+			break
+		}
 		newMoviesData = append(newMoviesData, newMovieItemTemplateData{
 			PosterURL:            newMovieItem.PosterURL,
 			Name:                 newMovieItem.Name,
@@ -453,7 +462,11 @@ func buildNewMediaTemplateData(
 		})
 	}
 
-	for _, newSeriesItem := range newJellyfinSeriesSorted {
+	for i, newSeriesItem := range newJellyfinSeriesSorted {
+		if app.Config.EmailTemplate.MaxDisplayedItems != 0 && i >= app.Config.EmailTemplate.MaxDisplayedItems {
+			app.Logger.Debug("MaxDisplayedItems setting reached. Next new items will be ignored.", zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems), zap.Int("newJellyfinMoviesSorted count", len(newJellyfinSeriesSorted)), zap.String("type", "series"))
+			break
+		}
 		newSeriesData = append(newSeriesData, newSeriesItemTemplateData{
 			PosterURL:            newSeriesItem.PosterURL,
 			SeriesName:           newSeriesItem.SeriesName,
@@ -485,30 +498,35 @@ func buildNewMediaTemplateData(
 	}
 
 	data := newMediaTemplateData{
-		HTMLLang:                     app.Config.EmailTemplate.Language,
-		HTMLDir:                      htmlDir,
-		Title:                        title,
-		Subtitle:                     subtitle,
-		JellyfinURL:                  app.Config.EmailTemplate.JellyfinURL,
-		DiscoverNowLabel:             app.Localizer.Localize("discover_now"),
-		DisplayNewMovies:             len(newMoviesData) > 0,
-		NewFilmLabel:                 app.Localizer.Localize("new_film"),
-		NewMovies:                    newMoviesData,
-		DisplayNewSeries:             len(newSeriesData) > 0,
-		NewSeriesLabel:               app.Localizer.Localize("new_tvs"),
-		NewSeries:                    newSeriesData,
-		CurrentlyAvailableLabel:      app.Localizer.Localize("currently_available"),
-		MoviesCount:                  strconv.Itoa(int(movieCount)),
-		SeriesCount:                  strconv.Itoa(int(episodesCount)),
-		MoviesLabel:                  app.Localizer.LocalizeWithPlural("movies", int(movieCount)),
-		SeriesLabel:                  app.Localizer.LocalizeWithPlural("episode", int(episodesCount)),
-		FooterLabel:                  buildFooterLabel(app),
-		FooterProjectLinkLabel:       "Jellyfin Newsletter",
-		FooterOpenSourceProjectLabel: app.Localizer.Localize("footer_project_open_source"),
-		FooterDevelopedByLabel:       app.Localizer.Localize("footer_developed_with_hearth"),
-		FooterLicenceAndCopyright:    app.Localizer.Localize("license_and_copyright"),
-		AndLocalized:                 app.Localizer.Localize("and"),
-		TheContributorsLabel:         app.Localizer.Localize("the_contributors"),
+		HTMLLang:                         app.Config.EmailTemplate.Language,
+		HTMLDir:                          htmlDir,
+		Title:                            title,
+		Subtitle:                         subtitle,
+		JellyfinURL:                      app.Config.EmailTemplate.JellyfinURL,
+		DiscoverNowLabel:                 app.Localizer.Localize("discover_now"),
+		DisplayNewMovies:                 len(newMoviesData) > 0,
+		NewFilmLabel:                     app.Localizer.Localize("new_film"),
+		NewMovies:                        newMoviesData,
+		RemainingMoviesNotDisplayedCount: len(newJellyfinMoviesSorted) - len(newMoviesData),
+		DisplayNewSeries:                 len(newSeriesData) > 0,
+		NewSeriesLabel:                   app.Localizer.Localize("new_tvs"),
+		NewSeries:                        newSeriesData,
+		RemainingSeriesNotDisplayedCount: len(newJellyfinSeriesSorted) - len(newSeriesData),
+		CurrentlyAvailableLabel:          app.Localizer.Localize("currently_available"),
+		MoviesCount:                      strconv.Itoa(int(movieCount)),
+		SeriesCount:                      strconv.Itoa(int(episodesCount)),
+		MoviesLabel:                      app.Localizer.LocalizeWithPlural("movies", int(movieCount)),
+		SeriesLabel:                      app.Localizer.LocalizeWithPlural("episode", int(episodesCount)),
+		FooterLabel:                      buildFooterLabel(app),
+		FooterProjectLinkLabel:           "Jellyfin Newsletter",
+		FooterOpenSourceProjectLabel:     app.Localizer.Localize("footer_project_open_source"),
+		FooterDevelopedByLabel:           app.Localizer.Localize("footer_developed_with_hearth"),
+		FooterLicenceAndCopyright:        app.Localizer.Localize("license_and_copyright"),
+		AndLocalized:                     app.Localizer.Localize("and"),
+		TheContributorsLabel:             app.Localizer.Localize("the_contributors"),
+		AndMoreTitlesPrefixLabel:         app.Localizer.Localize("and_more_titles_prefix_label"),
+		AndMoreTitlesSuffixLabelSeries:   app.Localizer.LocalizeWithPlural("and_more_titles_suffix_label", len(newJellyfinSeriesSorted)-len(newSeriesData)),
+		AndMoreTitlesSuffixLabelMovies:   app.Localizer.LocalizeWithPlural("and_more_titles_suffix_label", len(newJellyfinMoviesSorted)-len(newMoviesData)),
 	}
 	return &data, nil
 }

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -491,7 +491,6 @@ func buildNewMediaTemplateData(
 	movieCount int32,
 	episodesCount int32,
 	app *app.ApplicationContext) (*newMediaTemplateData, error) {
-
 	htmlDir := "ltr"
 	if slices.Contains(
 		[]string{"ar", "he", "fa", "ur", "ku", "ps", "yi", "dv", "qrc"},

--- a/engine-go/internal/template/builder.go
+++ b/engine-go/internal/template/builder.go
@@ -420,35 +420,22 @@ func getAdditionDateForSeries(seriesItem jellyfin.NewlyAddedSeriesItem) time.Tim
 	return additionDate
 }
 
-func buildNewMediaTemplateData(
-	newJellyfinMovies *[]jellyfin.MovieItem,
-	newJellyfinSeries *[]jellyfin.NewlyAddedSeriesItem,
-	movieCount int32,
-	episodesCount int32,
-	app *app.ApplicationContext) (*newMediaTemplateData, error) {
-	newMoviesData := []newMovieItemTemplateData{}
-	newSeriesData := []newSeriesItemTemplateData{}
-
-	htmlDir := "ltr"
-	if slices.Contains(
-		[]string{"ar", "he", "fa", "ur", "ku", "ps", "yi", "dv", "qrc"},
-		app.Config.EmailTemplate.Language,
-	) {
-		htmlDir = "rtl"
-	}
-
-	newJellyfinMoviesSorted := sortJellyfinNewMovies(newJellyfinMovies, app)
-
-	newJellyfinSeriesSorted := sortJellyfinNewSeriesItems(newJellyfinSeries, app)
-
+func getNewMovieTemplateDataFromSortedNewItems(
+	newJellyfinMoviesSorted []jellyfin.MovieItem,
+	app *app.ApplicationContext,
+) []newMovieItemTemplateData {
 	displayMovieOverviews := shouldOverviewsBeDisplayed(len(newJellyfinMoviesSorted), app)
-	displaySeriesOverviews := shouldOverviewsBeDisplayed(len(newJellyfinSeriesSorted), app)
-
 	jellyfinParsedURL, _ := url.Parse(app.Config.Jellyfin.URL)
+	newMoviesData := []newMovieItemTemplateData{}
 
 	for i, newMovieItem := range newJellyfinMoviesSorted {
 		if app.Config.EmailTemplate.MaxDisplayedItems != 0 && i >= app.Config.EmailTemplate.MaxDisplayedItems {
-			app.Logger.Debug("MaxDisplayedItems setting reached. Next new items will be ignored.", zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems), zap.Int("newJellyfinMoviesSorted count", len(newJellyfinMoviesSorted)), zap.String("type", "movies"))
+			app.Logger.Debug(
+				"MaxDisplayedItems setting reached. Next new items will be ignored.",
+				zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems),
+				zap.Int("newJellyfinMoviesSorted count", len(newJellyfinMoviesSorted)),
+				zap.String("type", "movies"),
+			)
 			break
 		}
 		newMoviesData = append(newMoviesData, newMovieItemTemplateData{
@@ -462,9 +449,25 @@ func buildNewMediaTemplateData(
 		})
 	}
 
+	return newMoviesData
+}
+
+func getNewSerieTemplatesDataFromSortedItems(
+	newJellyfinSeriesSorted []jellyfin.NewlyAddedSeriesItem,
+	app *app.ApplicationContext,
+) []newSeriesItemTemplateData {
+	displaySeriesOverviews := shouldOverviewsBeDisplayed(len(newJellyfinSeriesSorted), app)
+	jellyfinParsedURL, _ := url.Parse(app.Config.Jellyfin.URL)
+	newSeriesData := []newSeriesItemTemplateData{}
+
 	for i, newSeriesItem := range newJellyfinSeriesSorted {
 		if app.Config.EmailTemplate.MaxDisplayedItems != 0 && i >= app.Config.EmailTemplate.MaxDisplayedItems {
-			app.Logger.Debug("MaxDisplayedItems setting reached. Next new items will be ignored.", zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems), zap.Int("newJellyfinMoviesSorted count", len(newJellyfinSeriesSorted)), zap.String("type", "series"))
+			app.Logger.Debug(
+				"MaxDisplayedItems setting reached. Next new items will be ignored.",
+				zap.Int("MaxDisplayedItems", app.Config.EmailTemplate.MaxDisplayedItems),
+				zap.Int("newJellyfinMoviesSorted count", len(newJellyfinSeriesSorted)),
+				zap.String("type", "series"),
+			)
 			break
 		}
 		newSeriesData = append(newSeriesData, newSeriesItemTemplateData{
@@ -478,6 +481,30 @@ func buildNewMediaTemplateData(
 			MediaURL:             getMediaURL(jellyfinParsedURL, newSeriesItem.SeriesID),
 		})
 	}
+
+	return newSeriesData
+}
+
+func buildNewMediaTemplateData(
+	newJellyfinMovies *[]jellyfin.MovieItem,
+	newJellyfinSeries *[]jellyfin.NewlyAddedSeriesItem,
+	movieCount int32,
+	episodesCount int32,
+	app *app.ApplicationContext) (*newMediaTemplateData, error) {
+
+	htmlDir := "ltr"
+	if slices.Contains(
+		[]string{"ar", "he", "fa", "ur", "ku", "ps", "yi", "dv", "qrc"},
+		app.Config.EmailTemplate.Language,
+	) {
+		htmlDir = "rtl"
+	}
+
+	newJellyfinMoviesSorted := sortJellyfinNewMovies(newJellyfinMovies, app)
+	newMoviesData := getNewMovieTemplateDataFromSortedNewItems(newJellyfinMoviesSorted, app)
+
+	newJellyfinSeriesSorted := sortJellyfinNewSeriesItems(newJellyfinSeries, app)
+	newSeriesData := getNewSerieTemplatesDataFromSortedItems(newJellyfinSeriesSorted, app)
 
 	title, err := BuildEmailTitleWithPlaceholders(
 		app.Config.EmailTemplate.Title,
@@ -525,8 +552,14 @@ func buildNewMediaTemplateData(
 		AndLocalized:                     app.Localizer.Localize("and"),
 		TheContributorsLabel:             app.Localizer.Localize("the_contributors"),
 		AndMoreTitlesPrefixLabel:         app.Localizer.Localize("and_more_titles_prefix_label"),
-		AndMoreTitlesSuffixLabelSeries:   app.Localizer.LocalizeWithPlural("and_more_titles_suffix_label", len(newJellyfinSeriesSorted)-len(newSeriesData)),
-		AndMoreTitlesSuffixLabelMovies:   app.Localizer.LocalizeWithPlural("and_more_titles_suffix_label", len(newJellyfinMoviesSorted)-len(newMoviesData)),
+		AndMoreTitlesSuffixLabelSeries: app.Localizer.LocalizeWithPlural(
+			"and_more_titles_suffix_label",
+			len(newJellyfinSeriesSorted)-len(newSeriesData),
+		),
+		AndMoreTitlesSuffixLabelMovies: app.Localizer.LocalizeWithPlural(
+			"and_more_titles_suffix_label",
+			len(newJellyfinMoviesSorted)-len(newMoviesData),
+		),
 	}
 	return &data, nil
 }

--- a/engine-go/internal/template/builder_test.go
+++ b/engine-go/internal/template/builder_test.go
@@ -233,30 +233,35 @@ func getExpectedNewMediaTemplateData() newMediaTemplateData {
 	}
 
 	return newMediaTemplateData{
-		HTMLLang:                     "en",
-		HTMLDir:                      "ltr",
-		Title:                        title,
-		Subtitle:                     subtitle,
-		JellyfinURL:                  "https://jellyfin.example.com",
-		DiscoverNowLabel:             "Discover now",
-		DisplayNewMovies:             true,
-		NewFilmLabel:                 "New movies:",
-		NewMovies:                    newMovies,
-		DisplayNewSeries:             true,
-		NewSeriesLabel:               "New shows:",
-		NewSeries:                    newSeries,
-		CurrentlyAvailableLabel:      "Currently available in Jellyfin:",
-		MoviesCount:                  strconv.Itoa(54),
-		SeriesCount:                  strconv.Itoa(1253),
-		MoviesLabel:                  "Movies",
-		SeriesLabel:                  "Episodes",
-		FooterLabel:                  "You are recieving this email because you are using seaweedbrain's Jellyfin server. If you want to stop receiving these emails, you can unsubscribe by notifying stop@example.com.",
-		FooterProjectLinkLabel:       "Jellyfin Newsletter",
-		FooterOpenSourceProjectLabel: "is an open source project.",
-		FooterDevelopedByLabel:       "Developed with ❤️ by",
-		AndLocalized:                 "and",
-		TheContributorsLabel:         "the contributors",
-		FooterLicenceAndCopyright:    "Copyright © 2025 Nathan Stchepinsky, licensed under AGPLv3.",
+		HTMLLang:                         "en",
+		HTMLDir:                          "ltr",
+		Title:                            title,
+		Subtitle:                         subtitle,
+		JellyfinURL:                      "https://jellyfin.example.com",
+		DiscoverNowLabel:                 "Discover now",
+		DisplayNewMovies:                 true,
+		NewFilmLabel:                     "New movies:",
+		NewMovies:                        newMovies,
+		DisplayNewSeries:                 true,
+		NewSeriesLabel:                   "New shows:",
+		NewSeries:                        newSeries,
+		CurrentlyAvailableLabel:          "Currently available in Jellyfin:",
+		MoviesCount:                      strconv.Itoa(54),
+		SeriesCount:                      strconv.Itoa(1253),
+		RemainingMoviesNotDisplayedCount: 0,
+		RemainingSeriesNotDisplayedCount: 0,
+		MoviesLabel:                      "Movies",
+		SeriesLabel:                      "Episodes",
+		FooterLabel:                      "You are recieving this email because you are using seaweedbrain's Jellyfin server. If you want to stop receiving these emails, you can unsubscribe by notifying stop@example.com.",
+		FooterProjectLinkLabel:           "Jellyfin Newsletter",
+		FooterOpenSourceProjectLabel:     "is an open source project.",
+		FooterDevelopedByLabel:           "Developed with ❤️ by",
+		AndLocalized:                     "and",
+		TheContributorsLabel:             "the contributors",
+		FooterLicenceAndCopyright:        "Copyright © 2025 Nathan Stchepinsky, licensed under AGPLv3.",
+		AndMoreTitlesPrefixLabel:         "... and",
+		AndMoreTitlesSuffixLabelSeries:   "more titles!",
+		AndMoreTitlesSuffixLabelMovies:   "more titles!",
 	}
 }
 
@@ -590,6 +595,41 @@ func TestBuildNewMediaTemplateData(t *testing.T) {
 			movieCount:                54,
 			episodeCount:              1253,
 		},
+		{
+			name: "Max displayed item limit reached",
+			getAppContextFunc: func() (*app.ApplicationContext, *observer.ObservedLogs) {
+				app, obs := getAppContext()
+				app.Config.EmailTemplate.MaxDisplayedItems = 1
+				return app, obs
+			},
+			getExpectedNewMediaTemplateDataFunc: func() newMediaTemplateData {
+				expected := getExpectedNewMediaTemplateData()
+				newMovies := []newMovieItemTemplateData{}
+				newSeries := []newSeriesItemTemplateData{}
+
+				for i, movie := range expected.NewMovies {
+					if i < 1 {
+						newMovies = append(newMovies, movie)
+					}
+				}
+
+				for i, series := range expected.NewSeries {
+					if i < 1 {
+						newSeries = append(newSeries, series)
+					}
+				}
+				expected.NewMovies = newMovies
+				expected.NewSeries = newSeries
+				expected.RemainingMoviesNotDisplayedCount = 1
+				expected.RemainingSeriesNotDisplayedCount = 3
+				expected.AndMoreTitlesSuffixLabelMovies = "more title!"
+				return expected
+			},
+			getJellyfinNewMovies:      getJellyfinNewMovies,
+			getJellyfinNewSeriesItems: getJellyfinNewSeriesItems,
+			movieCount:                54,
+			episodeCount:              1253,
+		},
 	}
 
 	for _, test := range tests {
@@ -663,6 +703,7 @@ func TestBuildNewMediaEmailHTML(t *testing.T) {
 	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterOpenSourceProjectLabel)
 	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterDevelopedByLabel)
 	assert.Contains(t, unescapedHTML, expectedTemplateData.FooterLicenceAndCopyright)
+	assert.NotContains(t, unescapedHTML, expectedTemplateData.AndMoreTitlesSuffixLabelMovies)
 	for _, movies := range expectedTemplateData.NewMovies {
 		assert.Contains(t, unescapedHTML, movies.PosterURL)
 		assert.Contains(t, unescapedHTML, movies.Name)
@@ -758,4 +799,24 @@ func TestBuildNewMediaEmailHTMLWithThemeFallBack(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, unescapedHTML, expectedTemplateData.Subtitle)
+}
+
+func TestBuildNewMediaEmailHTMLWithMaxDisplayedItemsLimitReached(t *testing.T) {
+	newMovies := getJellyfinNewMovies()
+	newSeries := getJellyfinNewSeriesItems()
+	movieCount := int32(54)
+	seriesCount := int32(1253)
+	app, _ := getAppContext()
+	app.Config.EmailTemplate.MaxDisplayedItems = 1
+	expectedTemplateData := getExpectedNewMediaTemplateData()
+
+	escapedHTML, err := BuildNewMediaEmailHTML(&newMovies, &newSeries, movieCount, seriesCount, app)
+	unescapedHTML := html.UnescapeString(escapedHTML)
+
+	require.NoError(t, err)
+
+	assert.NotContains(t, unescapedHTML, "{{")
+	assert.NotContains(t, unescapedHTML, "}}")
+	assert.Contains(t, unescapedHTML, expectedTemplateData.AndMoreTitlesSuffixLabelMovies) // NotContains is checked in the main check
+
 }

--- a/engine-go/internal/template/builder_test.go
+++ b/engine-go/internal/template/builder_test.go
@@ -293,6 +293,7 @@ func getAppContext() (*app.ApplicationContext, *observer.ObservedLogs) {
 	}, recordedLogs
 }
 
+//nolint:gocognit // Long by design
 func TestBuildNewMediaTemplateData(t *testing.T) {
 	tests := []struct {
 		name                                string
@@ -817,6 +818,10 @@ func TestBuildNewMediaEmailHTMLWithMaxDisplayedItemsLimitReached(t *testing.T) {
 
 	assert.NotContains(t, unescapedHTML, "{{")
 	assert.NotContains(t, unescapedHTML, "}}")
-	assert.Contains(t, unescapedHTML, expectedTemplateData.AndMoreTitlesSuffixLabelMovies) // NotContains is checked in the main check
+	assert.Contains(
+		t,
+		unescapedHTML,
+		expectedTemplateData.AndMoreTitlesSuffixLabelMovies,
+	) // NotContains is checked in the main check
 
 }

--- a/engine-go/internal/template/builder_test.go
+++ b/engine-go/internal/template/builder_test.go
@@ -823,5 +823,4 @@ func TestBuildNewMediaEmailHTMLWithMaxDisplayedItemsLimitReached(t *testing.T) {
 		unescapedHTML,
 		expectedTemplateData.AndMoreTitlesSuffixLabelMovies,
 	) // NotContains is checked in the main check
-
 }

--- a/engine-go/internal/template/themes/classic/classic.html
+++ b/engine-go/internal/template/themes/classic/classic.html
@@ -154,6 +154,14 @@ Template: Classic
                 padding: 10px 15px;
             }
 
+            .more-titles {
+                text-align: center;
+                font-size: 13px !important;
+                font-style: italic;
+                color: #8fa3b8 !important;
+                margin: 0 0 15px !important;
+            }
+
             .stats-table {
                 width: 100%;
                 border-collapse: collapse;
@@ -247,6 +255,11 @@ Template: Classic
 
             /* Keep stats section title centered even in RTL */
             [dir="rtl"] h2[style*="text-align: center"] {
+                text-align: center !important;
+            }
+
+            /* Keep the "more titles" note centered even in RTL */
+            [dir="rtl"] .more-titles {
                 text-align: center !important;
             }
 
@@ -465,6 +478,13 @@ Template: Classic
                                 </a>
                                 {{end}}
                             </div>
+                            {{if (gt .RemainingMoviesNotDisplayedCount 0)}}
+                            <p class="more-titles">
+                                {{.AndMoreTitlesPrefixLabel}}
+                                {{.RemainingMoviesNotDisplayedCount}}
+                                {{.AndMoreTitlesSuffixLabelMovies}}
+                            </p>
+                            {{end}}
                         </div>
                         {{end}} {{if .DisplayNewSeries}}
                         <!-- TV Shows Section -->
@@ -575,6 +595,14 @@ Template: Classic
                                 </a>
                                 {{end}}
                             </div>
+                            {{if (gt .RemainingSeriesNotDisplayedCount 0)}}
+                            <p class="more-titles">
+                                {{.AndMoreTitlesPrefixLabel}}
+                                {{.RemainingSeriesNotDisplayedCount}}
+                                {{.AndMoreTitlesSuffixLabelSeries}}
+
+                            </p>
+                            {{end}}
                         </div>
                         {{end}}
 


### PR DESCRIPTION
Fix #151 

- Add a new parameter `max_displayed_items` under `email_template`:
   -  Optional 
   - If equals to 0 (default), all items will be displayed
   - Define the maximum number of items displayed in the newsletter
- Introduce localization in/by the template instead of providing them through struct keys